### PR TITLE
refactoring WindowGUISample

### DIFF
--- a/SamplesCS/Samples/PerspectiveTransformSample.cs
+++ b/SamplesCS/Samples/PerspectiveTransformSample.cs
@@ -1,8 +1,9 @@
 ﻿using OpenCvSharp;
 using System;
 using System.Collections.Generic;
+using SampleBase;
 
-namespace SamplesCS.Samples
+namespace SamplesCS
 {
     public class PerspectiveTransformSample : ISample
     {
@@ -27,7 +28,7 @@ namespace SamplesCS.Samples
         //PerspectiveTransform
         public void Run()
         {
-            OriginalImage = new Mat("./Resource.png", ImreadModes.AnyColor); // Your Resource
+            OriginalImage = new Mat(FilePath.Image.SurfBoxinscene, ImreadModes.AnyColor);
             using var Window = new Window("result", OriginalImage);
 
             Cv2.SetMouseCallback(Window.Name, CallbackOpenCVAnnotate);

--- a/SamplesCS/Samples/SuperResolutionSample.cs
+++ b/SamplesCS/Samples/SuperResolutionSample.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenCvSharp;
-using SamplesCS.Samples;
 
 namespace SamplesCS
 {

--- a/SamplesCS/Samples/WindowGUISample.cs
+++ b/SamplesCS/Samples/WindowGUISample.cs
@@ -1,14 +1,12 @@
 ﻿using OpenCvSharp;
 using System;
 using System.Diagnostics;
+using SampleBase;
 
-namespace SamplesCS.Samples
+namespace SamplesCS
 {
     internal class WindowGUISample : ISample
     {
-
-        Mat WindowImage = new Mat("./Resource.png", ImreadModes.AnyColor); // Set your Resource
-
         public void Run()
         {
             Windows_Example();
@@ -42,13 +40,15 @@ namespace SamplesCS.Samples
 
         public void Windows_Example()
         {
-            var openCloseWindow = new Window("OpenCVWindow", WindowMode.AutoSize, WindowImage);
+            using var srcImg = new Mat(FilePath.Image.SurfBoxinscene, ImreadModes.AnyColor);
+            using var openCloseWindow = new Window("OpenCVWindow", WindowMode.AutoSize, srcImg);
             Debug.WriteLine(Cv2.WaitKey());
         }
         
         public void MouseCallBack_Example()
         {
-            using Window foo = new Window("OpenCVWindow", WindowMode.AutoSize, WindowImage);
+            using var srcImg = new Mat(FilePath.Image.SurfBoxinscene, ImreadModes.AnyColor);
+            using Window foo = new Window("MouseEvent", WindowMode.AutoSize, srcImg);
             Cv2.SetMouseCallback(foo.Name, CallbackOpenCVAnnotate);
             Cv2.WaitKey();
         }
@@ -75,7 +75,7 @@ namespace SamplesCS.Samples
 
         public void TrackBar_Example()
         {
-            using var src = WindowImage;
+            using var src = new Mat(FilePath.Image.SurfBoxinscene, ImreadModes.AnyColor);
             using var dst = new Mat();
 
             src.CopyTo(dst);


### PR DESCRIPTION
A style of the source code added at #16 is different from the other samples.
So comment out  "//new WindowGUISample();" line from Program.cs file is not working immediately.

For ease of use, modified as below.
1. remove SamplesCS.Samples namespace.
2. replace resource file path with SampleBase project resource.
3. Enable continuous working for example in WindowGUISample.