### PR TITLE
Auto-discover samples via reflection instead of manual registration

### DIFF
--- a/Samples/Console/TestDiscovery.cs
+++ b/Samples/Console/TestDiscovery.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using SampleBase.Interfaces;
+
+namespace SampleBase.Console
+{
+    /// <summary>
+    /// Discovers <see cref="ITestBase"/> implementations via reflection, so that new samples
+    /// are picked up automatically without hand-editing a registration list.
+    /// </summary>
+    public static class TestDiscovery
+    {
+        public static IEnumerable<ITestBase> DiscoverTests(Assembly? assembly = null)
+        {
+            assembly ??= Assembly.GetExecutingAssembly();
+
+            return assembly.GetTypes()
+                .Where(t => typeof(ITestBase).IsAssignableFrom(t) && t is { IsClass: true, IsAbstract: false })
+                .Select(t =>
+                {
+                    var ctor = t.GetConstructor(Type.EmptyTypes)
+                        ?? throw new InvalidOperationException(
+                            $"{t.Name} implements {nameof(ITestBase)} but has no public parameterless constructor.");
+                    return (ITestBase)ctor.Invoke(null);
+                });
+        }
+    }
+}

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -1,7 +1,7 @@
-﻿using OpenCvSharp;
-using SampleBase.Console;
+﻿using SampleBase.Console;
 using SampleBase.Interfaces;
 using System;
+using System.Linq;
 
 namespace SamplesCore;
 
@@ -13,61 +13,9 @@ public static class Program
         Console.WriteLine("Runtime Version = {0}", Environment.Version);
 
         ITestManager testManager = new ConsoleTestManager();
-            
-        testManager.AddTests(
-            new ArucoSample(),
-            new BgSubtractorMOG(),
-            new BinarizerSample(),
-            new BRISKSample(),
-            new CameraCalibrationSample(),
-            new CameraCaptureSample(),
-            new ClaheSample(),
-            new ConnectedComponentsSample(),
-            new DFT(),
-            new DnnSuperresSample(),
-            new DrawBestMatchRectangle(),
-            new FaceDetection(),
-            new FASTSample(),
-            new FlannSample(),
-            new FREAKSample(),
-            new GrabCutSample(),
-            new HistSample(),
-            new HOGSample(),
-            new HoughLinesSample(),
-            new InpaintSample(),
-            new KAZESample(),
-            new KAZESample2(),
-            new MatOperations(),
-            new MDS(),
-            new MergeSplitSample(),
-            new MorphologySample(),
-            new MSERSample(),
-            new NormalArrayOperations(),
-            new ObjectTrackingSample(),
-            new OpticalFlowSample(),
-            new PerspectiveTransformSample(),
-            new PhotoMethods(),
-            new PixelAccess(),
-            new QRCodeDetectionSample(),
-            new SeamlessClone(),
-            new SiftSurfSample(),
-            new SimpleBlobDetectorSample(),
-            new SolveEquation(),
-            new SquareDetectionSample(),
-            new StarDetectorSample(),
-            new StereoMatchingSample(),
-            new Stitching(),
-            new Subdiv2DSample(),
-            new SVMSample(),
-            new VideoWriterSample(),
-            new VideoCaptureSample(),
-            new WatershedSample());
+
+        testManager.AddTests(TestDiscovery.DiscoverTests().OrderBy(t => t.Name).ToArray());
 
         testManager.ShowTestEntrance();
-
-
-
-        var mat = new Mat();
-        mat.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- `Program.cs` previously required every sample to be added by hand to a 47-entry `AddTests(...)` call. This is the exact bug class PR #47 hit (`PerspectiveTransformSample` existed but was never registered) — forgetting this step silently drops a sample from the menu with no error.
- Added `SampleBase.Console.TestDiscovery`, which scans the assembly for concrete `ITestBase` implementations and registers them automatically, sorted by name.
- This is PR1 of a stack aimed at improving the Samples project's management design (auto-registration → headless execution → folder/naming cleanup → interface simplification).

## Test plan
- [x] `dotnet build Samples/Samples.csproj` succeeds with 0 errors
- [x] Ran the sample menu and confirmed all 47 samples still appear, in the same set as before
- [x] Ran a sample end-to-end through the auto-discovered list to confirm execution still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of available console tests, so sample tests are now detected and loaded dynamically.
  * Test entries are now shown in a consistent sorted order.

* **Bug Fixes**
  * Removed reliance on manually maintained test registration, reducing the chance of missing samples.
  * Cleaned up leftover debug-only code from the sample app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->