### PR TITLE
Add headless execution support via a unified DisplayHelper

### DIFF
--- a/Samples/Console/ConsoleTestBase.cs
+++ b/Samples/Console/ConsoleTestBase.cs
@@ -21,7 +21,7 @@ namespace SampleBase.Console
             msgPrinter = new ConsoleMessagePrinter();
         }
 
-        public abstract void RunTest();
+        public abstract void RunTest(DisplayHelper display);
 
         public void PrintInfo(string message, bool newLine = true)
         {

--- a/Samples/Console/ConsoleTestManager.cs
+++ b/Samples/Console/ConsoleTestManager.cs
@@ -10,11 +10,13 @@ namespace SampleBase.Console
     {
         private readonly List<ITestBase> tests;
         private readonly IMessagePrinter msgPrinter;
+        private readonly bool isHeadless;
 
-        public ConsoleTestManager()
+        public ConsoleTestManager(bool isHeadless = false)
         {
             tests = new List<ITestBase>();
             msgPrinter = new ConsoleMessagePrinter();
+            this.isHeadless = isHeadless;
         }
 
         public void AddTest(ITestBase test)
@@ -124,10 +126,11 @@ namespace SampleBase.Console
                     var testName = GetNameOfTest(test);
                     msgPrinter.PrintSuccess($"{testName} start executing...");
 
+                    var display = new DisplayHelper(testName, isHeadless);
                     try
                     {
                         var watch = Stopwatch.StartNew();
-                        test.RunTest();
+                        test.RunTest(display);
                         watch.Stop();
                         msgPrinter.PrintSuccess($"{testName} completed, time cost:{watch.ElapsedMilliseconds}ms\n");
                     }
@@ -138,7 +141,7 @@ namespace SampleBase.Console
                     }
                     finally
                     {
-                        DisplayHelper.DestroyAll();
+                        display.DestroyAll();
                     }
 
                     input = PrintNamesAndRead();

--- a/Samples/Console/ConsoleTestManager.cs
+++ b/Samples/Console/ConsoleTestManager.cs
@@ -136,6 +136,10 @@ namespace SampleBase.Console
                         msgPrinter.PrintError(ex.Message);
                         msgPrinter.PrintError(ex.StackTrace ?? "");
                     }
+                    finally
+                    {
+                        DisplayHelper.DestroyAll();
+                    }
 
                     input = PrintNamesAndRead();
 

--- a/Samples/Console/DisplayHelper.cs
+++ b/Samples/Console/DisplayHelper.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using OpenCvSharp;
+
+namespace SampleBase.Console
+{
+    /// <summary>
+    /// Single entry point for showing sample output. Replaces direct use of
+    /// <see cref="Window"/>/<see cref="Cv2.ImShow"/>/<see cref="Cv2.WaitKey(int)"/> so that samples
+    /// can run without a display (set OPENCV_SAMPLES_HEADLESS=1, or run under CI where the
+    /// CI environment variable is set) by writing images to disk instead of opening windows.
+    /// </summary>
+    public static class DisplayHelper
+    {
+        public static bool IsHeadless { get; } =
+            Environment.GetEnvironmentVariable("OPENCV_SAMPLES_HEADLESS") is "1" or "true"
+            || Environment.GetEnvironmentVariable("CI") is not null;
+
+        private const string OutputRoot = "headless-output";
+
+        private static readonly Dictionary<string, Window> windowCache = new();
+        private static readonly Dictionary<string, int> headlessFrameCounts = new();
+
+        /// <summary>
+        /// Shows a single image, or writes it to disk when headless.
+        /// </summary>
+        public static void Show(string sampleName, string title, Mat image)
+        {
+            Show(sampleName, new[] { title }, new[] { image });
+        }
+
+        /// <summary>
+        /// Shows one window per image/title pair, or writes them to disk when headless.
+        /// </summary>
+        public static void Show(string sampleName, string[] titles, Mat[] images)
+        {
+            if (IsHeadless)
+            {
+                for (int i = 0; i < images.Length; i++)
+                {
+                    WriteToDisk(sampleName, titles[i], images[i]);
+                }
+                return;
+            }
+
+            Window.ShowImages(images, titles);
+        }
+
+        /// <summary>
+        /// Shows a single video frame; call once per loop iteration. Returns false when the
+        /// caller should stop looping (either the user asked to quit, or the headless frame cap
+        /// was reached).
+        /// </summary>
+        public static bool ShowFrame(string sampleName, string title, Mat frame, int waitMs = 30, int maxHeadlessFrames = 5)
+        {
+            return ShowFrame(sampleName, new[] { title }, new[] { frame }, waitMs, maxHeadlessFrames);
+        }
+
+        /// <summary>
+        /// Shows multiple simultaneous video frames (e.g. "src"/"dst" side by side) with a single
+        /// wait per iteration. Windows are kept open and updated in place across calls, matching
+        /// the original new Window(...) + Image-property-update pattern.
+        /// </summary>
+        public static bool ShowFrame(string sampleName, string[] titles, Mat[] frames, int waitMs = 30, int maxHeadlessFrames = 5)
+        {
+            if (IsHeadless)
+            {
+                headlessFrameCounts.TryGetValue(sampleName, out int count);
+                if (count >= maxHeadlessFrames)
+                    return false;
+
+                for (int i = 0; i < frames.Length; i++)
+                {
+                    WriteToDisk(sampleName, $"{titles[i]}_{count:D3}", frames[i]);
+                }
+                headlessFrameCounts[sampleName] = count + 1;
+                return true;
+            }
+
+            for (int i = 0; i < frames.Length; i++)
+            {
+                if (!windowCache.TryGetValue(titles[i], out var window))
+                {
+                    window = new Window(titles[i]);
+                    windowCache[titles[i]] = window;
+                }
+                window.Image = frames[i];
+            }
+            return Cv2.WaitKey(waitMs) < 0;
+        }
+
+        /// <summary>
+        /// Closes any windows opened by <see cref="ShowFrame(string,string,Mat,int,int)"/>. Called
+        /// once per sample run by <see cref="ConsoleTestManager"/>; a no-op when headless.
+        /// </summary>
+        public static void DestroyAll()
+        {
+            if (IsHeadless)
+                return;
+
+            foreach (var window in windowCache.Values)
+                window.Dispose();
+            windowCache.Clear();
+            Cv2.DestroyAllWindows();
+        }
+
+        private static void WriteToDisk(string sampleName, string title, Mat image)
+        {
+            string dir = Path.Combine(OutputRoot, sampleName);
+            Directory.CreateDirectory(dir);
+            string safeTitle = string.Join("_", title.Split(Path.GetInvalidFileNameChars()));
+            Cv2.ImWrite(Path.Combine(dir, $"{safeTitle}.png"), image);
+        }
+    }
+}

--- a/Samples/Console/DisplayHelper.cs
+++ b/Samples/Console/DisplayHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenCvSharp;
@@ -8,14 +7,20 @@ namespace SampleBase.Console
     /// <summary>
     /// Single entry point for showing sample output. Replaces direct use of
     /// <see cref="Window"/>/<see cref="Cv2.ImShow"/>/<see cref="Cv2.WaitKey(int)"/> so that samples
-    /// can run without a display (set OPENCV_SAMPLES_HEADLESS=1, or run under CI where the
-    /// CI environment variable is set) by writing images to disk instead of opening windows.
+    /// can run without a display (pass --headless, or set OPENCV_SAMPLES_HEADLESS=1) by writing
+    /// images to disk instead of opening windows.
     /// </summary>
     public static class DisplayHelper
     {
-        public static bool IsHeadless { get; } =
-            Environment.GetEnvironmentVariable("OPENCV_SAMPLES_HEADLESS") is "1" or "true"
-            || Environment.GetEnvironmentVariable("CI") is not null;
+        /// <summary>
+        /// Set once by <see cref="SamplesCore.Program"/> at startup, from configuration.
+        /// </summary>
+        public static bool IsHeadless { get; private set; }
+
+        public static void Initialize(bool headless)
+        {
+            IsHeadless = headless;
+        }
 
         private const string OutputRoot = "headless-output";
 
@@ -23,46 +28,40 @@ namespace SampleBase.Console
         private static readonly Dictionary<string, int> headlessFrameCounts = new();
 
         /// <summary>
-        /// Shows a single image, or writes it to disk when headless.
+        /// Shows one window per (title, image) pair, or writes them to disk when headless.
         /// </summary>
-        public static void Show(string sampleName, string title, Mat image)
-        {
-            Show(sampleName, new[] { title }, new[] { image });
-        }
-
-        /// <summary>
-        /// Shows one window per image/title pair, or writes them to disk when headless.
-        /// </summary>
-        public static void Show(string sampleName, string[] titles, Mat[] images)
+        public static void Show(string sampleName, params (string Title, Mat Image)[] frames)
         {
             if (IsHeadless)
             {
-                for (int i = 0; i < images.Length; i++)
+                foreach (var (title, image) in frames)
                 {
-                    WriteToDisk(sampleName, titles[i], images[i]);
+                    WriteToDisk(sampleName, title, image);
                 }
                 return;
             }
 
+            var titles = new string[frames.Length];
+            var images = new Mat[frames.Length];
+            for (int i = 0; i < frames.Length; i++)
+            {
+                titles[i] = frames[i].Title;
+                images[i] = frames[i].Image;
+            }
             Window.ShowImages(images, titles);
         }
 
         /// <summary>
-        /// Shows a single video frame; call once per loop iteration. Returns false when the
-        /// caller should stop looping (either the user asked to quit, or the headless frame cap
-        /// was reached).
+        /// Shows one or more simultaneous video frames (e.g. "src"/"dst" side by side) with a
+        /// single wait per iteration; call once per loop iteration. Returns false when the caller
+        /// should stop looping (either the user asked to quit, or the headless frame cap was
+        /// reached). Windows are kept open and updated in place across calls, matching the
+        /// original new Window(...) + Image-property-update pattern.
         /// </summary>
-        public static bool ShowFrame(string sampleName, string title, Mat frame, int waitMs = 30, int maxHeadlessFrames = 5)
-        {
-            return ShowFrame(sampleName, new[] { title }, new[] { frame }, waitMs, maxHeadlessFrames);
-        }
+        public static bool ShowFrame(string sampleName, params (string Title, Mat Frame)[] frames)
+            => ShowFrame(sampleName, waitMs: 30, maxHeadlessFrames: 5, frames);
 
-        /// <summary>
-        /// Shows multiple simultaneous video frames (e.g. "src"/"dst" side by side) with a single
-        /// wait per iteration. Windows are kept open and updated in place across calls, matching
-        /// the original new Window(...) + Image-property-update pattern.
-        /// </summary>
-        public static bool ShowFrame(string sampleName, string[] titles, Mat[] frames, int waitMs = 30, int maxHeadlessFrames = 5)
+        public static bool ShowFrame(string sampleName, int waitMs, int maxHeadlessFrames, params (string Title, Mat Frame)[] frames)
         {
             if (IsHeadless)
             {
@@ -70,28 +69,28 @@ namespace SampleBase.Console
                 if (count >= maxHeadlessFrames)
                     return false;
 
-                for (int i = 0; i < frames.Length; i++)
+                foreach (var (title, frame) in frames)
                 {
-                    WriteToDisk(sampleName, $"{titles[i]}_{count:D3}", frames[i]);
+                    WriteToDisk(sampleName, $"{title}_{count:D3}", frame);
                 }
                 headlessFrameCounts[sampleName] = count + 1;
                 return true;
             }
 
-            for (int i = 0; i < frames.Length; i++)
+            foreach (var (title, frame) in frames)
             {
-                if (!windowCache.TryGetValue(titles[i], out var window))
+                if (!windowCache.TryGetValue(title, out var window))
                 {
-                    window = new Window(titles[i]);
-                    windowCache[titles[i]] = window;
+                    window = new Window(title);
+                    windowCache[title] = window;
                 }
-                window.Image = frames[i];
+                window.Image = frame;
             }
             return Cv2.WaitKey(waitMs) < 0;
         }
 
         /// <summary>
-        /// Closes any windows opened by <see cref="ShowFrame(string,string,Mat,int,int)"/>. Called
+        /// Closes any windows opened by <see cref="ShowFrame(string, (string, Mat)[])"/>. Called
         /// once per sample run by <see cref="ConsoleTestManager"/>; a no-op when headless.
         /// </summary>
         public static void DestroyAll()

--- a/Samples/Interfaces/DisplayHelper.cs
+++ b/Samples/Interfaces/DisplayHelper.cs
@@ -2,41 +2,42 @@ using System.Collections.Generic;
 using System.IO;
 using OpenCvSharp;
 
-namespace SampleBase.Console
+namespace SampleBase.Interfaces
 {
     /// <summary>
-    /// Single entry point for showing sample output. Replaces direct use of
-    /// <see cref="Window"/>/<see cref="Cv2.ImShow"/>/<see cref="Cv2.WaitKey(int)"/> so that samples
-    /// can run without a display (pass --headless, or set OPENCV_SAMPLES_HEADLESS=1) by writing
-    /// images to disk instead of opening windows.
+    /// Per-run helper for showing a sample's output. Replaces direct use of
+    /// <see cref="Window"/>/<see cref="Cv2.ImShow"/>/<see cref="Cv2.WaitKey(int)"/> so that a
+    /// sample can run without a display (headless mode) by writing images to disk instead of
+    /// opening windows. One instance is created per test run and passed into
+    /// <see cref="ITestBase.RunTest"/>, so its state never leaks between samples or between
+    /// repeated runs of the same sample.
     /// </summary>
-    public static class DisplayHelper
+    public sealed class DisplayHelper
     {
-        /// <summary>
-        /// Set once by <see cref="SamplesCore.Program"/> at startup, from configuration.
-        /// </summary>
-        public static bool IsHeadless { get; private set; }
-
-        public static void Initialize(bool headless)
-        {
-            IsHeadless = headless;
-        }
-
         private const string OutputRoot = "headless-output";
 
-        private static readonly Dictionary<string, Window> windowCache = new();
-        private static readonly Dictionary<string, int> headlessFrameCounts = new();
+        private readonly string sampleName;
+        private readonly Dictionary<string, Window> windowCache = new();
+        private int headlessFrameCount;
+
+        public bool IsHeadless { get; }
+
+        public DisplayHelper(string sampleName, bool isHeadless)
+        {
+            this.sampleName = sampleName;
+            IsHeadless = isHeadless;
+        }
 
         /// <summary>
         /// Shows one window per (title, image) pair, or writes them to disk when headless.
         /// </summary>
-        public static void Show(string sampleName, params (string Title, Mat Image)[] frames)
+        public void Show(params (string Title, Mat Image)[] frames)
         {
             if (IsHeadless)
             {
                 foreach (var (title, image) in frames)
                 {
-                    WriteToDisk(sampleName, title, image);
+                    WriteToDisk(title, image);
                 }
                 return;
             }
@@ -58,22 +59,21 @@ namespace SampleBase.Console
         /// reached). Windows are kept open and updated in place across calls, matching the
         /// original new Window(...) + Image-property-update pattern.
         /// </summary>
-        public static bool ShowFrame(string sampleName, params (string Title, Mat Frame)[] frames)
-            => ShowFrame(sampleName, waitMs: 30, maxHeadlessFrames: 5, frames);
+        public bool ShowFrame(params (string Title, Mat Frame)[] frames)
+            => ShowFrame(waitMs: 30, maxHeadlessFrames: 5, frames);
 
-        public static bool ShowFrame(string sampleName, int waitMs, int maxHeadlessFrames, params (string Title, Mat Frame)[] frames)
+        public bool ShowFrame(int waitMs, int maxHeadlessFrames, params (string Title, Mat Frame)[] frames)
         {
             if (IsHeadless)
             {
-                headlessFrameCounts.TryGetValue(sampleName, out int count);
-                if (count >= maxHeadlessFrames)
+                if (headlessFrameCount >= maxHeadlessFrames)
                     return false;
 
                 foreach (var (title, frame) in frames)
                 {
-                    WriteToDisk(sampleName, $"{title}_{count:D3}", frame);
+                    WriteToDisk($"{title}_{headlessFrameCount:D3}", frame);
                 }
-                headlessFrameCounts[sampleName] = count + 1;
+                headlessFrameCount++;
                 return true;
             }
 
@@ -90,10 +90,10 @@ namespace SampleBase.Console
         }
 
         /// <summary>
-        /// Closes any windows opened by <see cref="ShowFrame(string, (string, Mat)[])"/>. Called
-        /// once per sample run by <see cref="ConsoleTestManager"/>; a no-op when headless.
+        /// Closes any windows opened by <see cref="ShowFrame(int, int, (string, Mat)[])"/>. Called
+        /// once per sample run by <c>ConsoleTestManager</c>; a no-op when headless.
         /// </summary>
-        public static void DestroyAll()
+        public void DestroyAll()
         {
             if (IsHeadless)
                 return;
@@ -104,7 +104,7 @@ namespace SampleBase.Console
             Cv2.DestroyAllWindows();
         }
 
-        private static void WriteToDisk(string sampleName, string title, Mat image)
+        private void WriteToDisk(string title, Mat image)
         {
             string dir = Path.Combine(OutputRoot, sampleName);
             Directory.CreateDirectory(dir);

--- a/Samples/Interfaces/ITestBase.cs
+++ b/Samples/Interfaces/ITestBase.cs
@@ -57,7 +57,8 @@ namespace SampleBase.Interfaces
         /// <summary>
         /// Run current test
         /// </summary>
-        void RunTest();
+        /// <param name="display">Per-run helper for showing results; see <see cref="DisplayHelper"/>.</param>
+        void RunTest(DisplayHelper display);
 
         /// <summary>
         /// Waiting for input to complete, and take it as return value

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -21,9 +21,8 @@ public static class Program
             .AddEnvironmentVariables(prefix: "OPENCV_SAMPLES_")
             .Build();
         bool headless = args.Contains("--headless") || configuration["Headless"] is "1" or "true";
-        DisplayHelper.Initialize(headless);
 
-        ITestManager testManager = new ConsoleTestManager();
+        ITestManager testManager = new ConsoleTestManager(headless);
 
         testManager.AddTests(TestDiscovery.DiscoverTests().OrderBy(t => t.Name).ToArray());
 

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -1,4 +1,5 @@
-﻿using SampleBase.Console;
+﻿using Microsoft.Extensions.Configuration;
+using SampleBase.Console;
 using SampleBase.Interfaces;
 using System;
 using System.Linq;
@@ -8,9 +9,19 @@ namespace SamplesCore;
 public static class Program
 {
     [STAThread]
-    public static void Main()
+    public static void Main(string[] args)
     {
         Console.WriteLine("Runtime Version = {0}", Environment.Version);
+
+        // Env var: OPENCV_SAMPLES_HEADLESS=1 (via Configuration rather than a raw
+        // Environment.GetEnvironmentVariable lookup). CLI: --headless.
+        // AddCommandLine doesn't support a bare value-less switch meaning "true", so that part is
+        // just a plain args check.
+        var configuration = new ConfigurationBuilder()
+            .AddEnvironmentVariables(prefix: "OPENCV_SAMPLES_")
+            .Build();
+        bool headless = args.Contains("--headless") || configuration["Headless"] is "1" or "true";
+        DisplayHelper.Initialize(headless);
 
         ITestManager testManager = new ConsoleTestManager();
 

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -17,6 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageReference Include="OpenCvSharp5.GdipExtensions" Version="5.0.0.20260702" />
     <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260702" />
   </ItemGroup>

--- a/Samples/Samples/ArucoSample.cs
+++ b/Samples/Samples/ArucoSample.cs
@@ -72,6 +72,6 @@ public class ArucoSample : ConsoleTestBase
         using var normalizedImage = new Mat();
         Cv2.WarpPerspective(src, normalizedImage, transform, new Size(1024, 1024));
 
-        DisplayHelper.Show(nameof(ArucoSample), new[] { "Original Image", $"Found {ids.Length} Markers", "Normalized Image" }, new[] { src, detectedMarkers, normalizedImage });
+        DisplayHelper.Show(nameof(ArucoSample), ("Original Image", src), ($"Found {ids.Length} Markers", detectedMarkers), ("Normalized Image", normalizedImage));
     }
 }

--- a/Samples/Samples/ArucoSample.cs
+++ b/Samples/Samples/ArucoSample.cs
@@ -4,12 +4,13 @@ using OpenCvSharp;
 using OpenCvSharp.Aruco;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 public class ArucoSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         // The locations of the markers in the image at FilePath.Image.Aruco.
         const int upperLeftMarkerId = 160;
@@ -72,6 +73,6 @@ public class ArucoSample : ConsoleTestBase
         using var normalizedImage = new Mat();
         Cv2.WarpPerspective(src, normalizedImage, transform, new Size(1024, 1024));
 
-        DisplayHelper.Show(nameof(ArucoSample), ("Original Image", src), ($"Found {ids.Length} Markers", detectedMarkers), ("Normalized Image", normalizedImage));
+        display.Show(("Original Image", src), ($"Found {ids.Length} Markers", detectedMarkers), ("Normalized Image", normalizedImage));
     }
 }

--- a/Samples/Samples/ArucoSample.cs
+++ b/Samples/Samples/ArucoSample.cs
@@ -72,10 +72,6 @@ public class ArucoSample : ConsoleTestBase
         using var normalizedImage = new Mat();
         Cv2.WarpPerspective(src, normalizedImage, transform, new Size(1024, 1024));
 
-        using var _1 = new Window("Original Image", src, WindowFlags.AutoSize);
-        using var _2 = new Window($"Found {ids.Length} Markers", detectedMarkers);
-        using var _3 = new Window("Normalized Image", normalizedImage);
-
-        Cv2.WaitKey();
+        DisplayHelper.Show(nameof(ArucoSample), new[] { "Original Image", $"Found {ids.Length} Markers", "Normalized Image" }, new[] { src, detectedMarkers, normalizedImage });
     }
 }

--- a/Samples/Samples/BRISKSample.cs
+++ b/Samples/Samples/BRISKSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class BRISKSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         var gray = new Mat(ImagePath.Penguin1, ImreadModes.Grayscale);
         var dst = new Mat(ImagePath.Penguin1, ImreadModes.Color);
@@ -36,6 +37,6 @@ class BRISKSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(BRISKSample), ("BRISK features", dst));
+        display.Show(("BRISK features", dst));
     }
 }

--- a/Samples/Samples/BRISKSample.cs
+++ b/Samples/Samples/BRISKSample.cs
@@ -36,9 +36,6 @@ class BRISKSample : ConsoleTestBase
             }
         }
 
-        using (new Window("BRISK features", dst))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(BRISKSample), "BRISK features", dst);
     }
 }

--- a/Samples/Samples/BRISKSample.cs
+++ b/Samples/Samples/BRISKSample.cs
@@ -36,6 +36,6 @@ class BRISKSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(BRISKSample), "BRISK features", dst);
+        DisplayHelper.Show(nameof(BRISKSample), ("BRISK features", dst));
     }
 }

--- a/Samples/Samples/BgSubtractorMOG.cs
+++ b/Samples/Samples/BgSubtractorMOG.cs
@@ -20,7 +20,7 @@ class BgSubtractorMOG : ConsoleTestBase
                 break;
             mog.Apply(frame, fg, 0.01);
 
-            if (!DisplayHelper.ShowFrame(nameof(BgSubtractorMOG), new[] { "src", "dst" }, new[] { frame, fg }, 50))
+            if (!DisplayHelper.ShowFrame(nameof(BgSubtractorMOG), waitMs: 50, maxHeadlessFrames: 5, ("src", frame), ("dst", fg)))
                 break;
         }
     }

--- a/Samples/Samples/BgSubtractorMOG.cs
+++ b/Samples/Samples/BgSubtractorMOG.cs
@@ -10,8 +10,6 @@ class BgSubtractorMOG : ConsoleTestBase
     {
         using var capture = new VideoCapture(MoviePath.Bach);
         using var mog = BackgroundSubtractorMOG.Create();
-        using var windowSrc = new Window("src");
-        using var windowDst = new Window("dst");
 
         using var frame = new Mat();
         using var fg = new Mat();
@@ -22,9 +20,8 @@ class BgSubtractorMOG : ConsoleTestBase
                 break;
             mog.Apply(frame, fg, 0.01);
 
-            windowSrc.Image = frame;
-            windowDst.Image = fg;
-            Cv2.WaitKey(50);
+            if (!DisplayHelper.ShowFrame(nameof(BgSubtractorMOG), new[] { "src", "dst" }, new[] { frame, fg }, 50))
+                break;
         }
     }
 }

--- a/Samples/Samples/BgSubtractorMOG.cs
+++ b/Samples/Samples/BgSubtractorMOG.cs
@@ -1,12 +1,13 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 class BgSubtractorMOG : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var capture = new VideoCapture(MoviePath.Bach);
         using var mog = BackgroundSubtractorMOG.Create();
@@ -20,7 +21,7 @@ class BgSubtractorMOG : ConsoleTestBase
                 break;
             mog.Apply(frame, fg, 0.01);
 
-            if (!DisplayHelper.ShowFrame(nameof(BgSubtractorMOG), waitMs: 50, maxHeadlessFrames: 5, ("src", frame), ("dst", fg)))
+            if (!display.ShowFrame(waitMs: 50, maxHeadlessFrames: 5, ("src", frame), ("dst", fg)))
                 break;
         }
     }

--- a/Samples/Samples/BinarizerSample.cs
+++ b/Samples/Samples/BinarizerSample.cs
@@ -33,6 +33,6 @@ internal class BinarizerSample : ConsoleTestBase
         sw.Stop();
         Console.WriteLine($"Nick {sw.ElapsedMilliseconds} ms");
 
-        DisplayHelper.Show(nameof(BinarizerSample), new[] { "src", "Niblack", "Sauvola", "Nick" }, new[] { src, niblack, sauvola, nick });
+        DisplayHelper.Show(nameof(BinarizerSample), ("src", src), ("Niblack", niblack), ("Sauvola", sauvola), ("Nick", nick));
     }
 }

--- a/Samples/Samples/BinarizerSample.cs
+++ b/Samples/Samples/BinarizerSample.cs
@@ -4,12 +4,13 @@ using OpenCvSharp;
 using OpenCvSharp.XImgProc;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 internal class BinarizerSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Binarization, ImreadModes.Grayscale);
         using var niblack = new Mat();
@@ -33,6 +34,6 @@ internal class BinarizerSample : ConsoleTestBase
         sw.Stop();
         Console.WriteLine($"Nick {sw.ElapsedMilliseconds} ms");
 
-        DisplayHelper.Show(nameof(BinarizerSample), ("src", src), ("Niblack", niblack), ("Sauvola", sauvola), ("Nick", nick));
+        display.Show(("src", src), ("Niblack", niblack), ("Sauvola", sauvola), ("Nick", nick));
     }
 }

--- a/Samples/Samples/BinarizerSample.cs
+++ b/Samples/Samples/BinarizerSample.cs
@@ -33,12 +33,6 @@ internal class BinarizerSample : ConsoleTestBase
         sw.Stop();
         Console.WriteLine($"Nick {sw.ElapsedMilliseconds} ms");
 
-        using (new Window("src", src, WindowFlags.AutoSize))
-        using (new Window("Niblack", niblack, WindowFlags.AutoSize))
-        using (new Window("Sauvola", sauvola, WindowFlags.AutoSize))
-        using (new Window("Nick", nick, WindowFlags.AutoSize))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(BinarizerSample), new[] { "src", "Niblack", "Sauvola", "Nick" }, new[] { src, niblack, sauvola, nick });
     }
 }

--- a/Samples/Samples/CameraCalibrationSample.cs
+++ b/Samples/Samples/CameraCalibrationSample.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -20,7 +21,7 @@ class CameraCalibrationSample : ConsoleTestBase
         .Select(i => string.Format(ImagePath.CalibrationLeft, i))
         .ToArray();
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         var objectPoints = new List<Point3f[]>();
         var imagePoints = new List<Point2f[]>();
@@ -87,10 +88,10 @@ class CameraCalibrationSample : ConsoleTestBase
         {
             using (img)
             {
-                DisplayHelper.Show(nameof(CameraCalibrationSample), ("detected corners", img));
+                display.Show(("detected corners", img));
             }
         }
 
-        DisplayHelper.Show(nameof(CameraCalibrationSample), ("original", sample), ("undistorted", undistorted));
+        display.Show(("original", sample), ("undistorted", undistorted));
     }
 }

--- a/Samples/Samples/CameraCalibrationSample.cs
+++ b/Samples/Samples/CameraCalibrationSample.cs
@@ -87,10 +87,10 @@ class CameraCalibrationSample : ConsoleTestBase
         {
             using (img)
             {
-                DisplayHelper.Show(nameof(CameraCalibrationSample), "detected corners", img);
+                DisplayHelper.Show(nameof(CameraCalibrationSample), ("detected corners", img));
             }
         }
 
-        DisplayHelper.Show(nameof(CameraCalibrationSample), new[] { "original", "undistorted" }, new[] { sample, undistorted });
+        DisplayHelper.Show(nameof(CameraCalibrationSample), ("original", sample), ("undistorted", undistorted));
     }
 }

--- a/Samples/Samples/CameraCalibrationSample.cs
+++ b/Samples/Samples/CameraCalibrationSample.cs
@@ -86,16 +86,11 @@ class CameraCalibrationSample : ConsoleTestBase
         foreach (var img in annotated)
         {
             using (img)
-            using (new Window("detected corners", img))
             {
-                Cv2.WaitKey();
+                DisplayHelper.Show(nameof(CameraCalibrationSample), "detected corners", img);
             }
         }
 
-        using (new Window("original", sample))
-        using (new Window("undistorted", undistorted))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(CameraCalibrationSample), new[] { "original", "undistorted" }, new[] { sample, undistorted });
     }
 }

--- a/Samples/Samples/CameraCaptureSample.cs
+++ b/Samples/Samples/CameraCaptureSample.cs
@@ -34,7 +34,7 @@ class CameraCaptureSample : ConsoleTestBase
             if (image.Empty())
                 break;
 
-            if (!DisplayHelper.ShowFrame(nameof(CameraCaptureSample), "capture", image, sleepTime))
+            if (!DisplayHelper.ShowFrame(nameof(CameraCaptureSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
                 break;
         }
     }

--- a/Samples/Samples/CameraCaptureSample.cs
+++ b/Samples/Samples/CameraCaptureSample.cs
@@ -10,6 +10,12 @@ class CameraCaptureSample : ConsoleTestBase
 {
     public override void RunTest()
     {
+        if (DisplayHelper.IsHeadless)
+        {
+            PrintWarning("Skipping: this sample needs a live camera and cannot be meaningfully verified headlessly.");
+            return;
+        }
+
         using var capture = new VideoCapture(0, VideoCaptureAPIs.DSHOW);
         if (!capture.IsOpened())
             return;
@@ -20,7 +26,6 @@ class CameraCaptureSample : ConsoleTestBase
 
         const int sleepTime = 10;
 
-        using var window = new Window("capture");
         var image = new Mat();
 
         while (true)
@@ -29,12 +34,8 @@ class CameraCaptureSample : ConsoleTestBase
             if (image.Empty())
                 break;
 
-            window.ShowImage(image);
-            int c = Cv2.WaitKey(sleepTime);
-            if (c >= 0)
-            {
+            if (!DisplayHelper.ShowFrame(nameof(CameraCaptureSample), "capture", image, sleepTime))
                 break;
-            }
         }
     }
 }

--- a/Samples/Samples/CameraCaptureSample.cs
+++ b/Samples/Samples/CameraCaptureSample.cs
@@ -1,5 +1,6 @@
 ﻿using OpenCvSharp;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -8,9 +9,9 @@ namespace SamplesCore;
 /// </summary>
 class CameraCaptureSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        if (DisplayHelper.IsHeadless)
+        if (display.IsHeadless)
         {
             PrintWarning("Skipping: this sample needs a live camera and cannot be meaningfully verified headlessly.");
             return;
@@ -34,7 +35,7 @@ class CameraCaptureSample : ConsoleTestBase
             if (image.Empty())
                 break;
 
-            if (!DisplayHelper.ShowFrame(nameof(CameraCaptureSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
+            if (!display.ShowFrame(waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
                 break;
         }
     }

--- a/Samples/Samples/ClaheSample.cs
+++ b/Samples/Samples/ClaheSample.cs
@@ -1,12 +1,13 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 class ClaheSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = new Mat(ImagePath.TsukubaLeft, ImreadModes.Grayscale);
         using var dst1 = new Mat();
@@ -23,6 +24,6 @@ class ClaheSample : ConsoleTestBase
             clahe.Apply(src, dst3);
         }
 
-        DisplayHelper.Show(nameof(ClaheSample), ("src", src), ("dst clip20", dst1), ("dst clip40", dst2), ("dst tile4x4", dst3));
+        display.Show(("src", src), ("dst clip20", dst1), ("dst clip40", dst2), ("dst tile4x4", dst3));
     }
 }

--- a/Samples/Samples/ClaheSample.cs
+++ b/Samples/Samples/ClaheSample.cs
@@ -23,6 +23,6 @@ class ClaheSample : ConsoleTestBase
             clahe.Apply(src, dst3);
         }
 
-        DisplayHelper.Show(nameof(ClaheSample), new[] { "src", "dst clip20", "dst clip40", "dst tile4x4" }, new[] { src, dst1, dst2, dst3 });
+        DisplayHelper.Show(nameof(ClaheSample), ("src", src), ("dst clip20", dst1), ("dst clip40", dst2), ("dst tile4x4", dst3));
     }
 }

--- a/Samples/Samples/ClaheSample.cs
+++ b/Samples/Samples/ClaheSample.cs
@@ -23,8 +23,6 @@ class ClaheSample : ConsoleTestBase
             clahe.Apply(src, dst3);
         }
 
-        Window.ShowImages(
-            new[] { src, dst1, dst2, dst3 },
-            new[] { "src", "dst clip20", "dst clip40", "dst tile4x4" });
+        DisplayHelper.Show(nameof(ClaheSample), new[] { "src", "dst clip20", "dst clip40", "dst tile4x4" }, new[] { src, dst1, dst2, dst3 });
     }
 }

--- a/Samples/Samples/ConnectedComponentsSample.cs
+++ b/Samples/Samples/ConnectedComponentsSample.cs
@@ -39,13 +39,8 @@ class ConnectedComponentsSample : ConsoleTestBase
         var filtered = new Mat();
         cc.FilterByBlob(src, filtered, maxBlob);
 
-        using (new Window("src", src))
-        using (new Window("binary", binary))
-        using (new Window("labels", labelView))
-        using (new Window("bonding boxes", rectView))
-        using (new Window("maximum blob", filtered))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(ConnectedComponentsSample),
+            new[] { "src", "binary", "labels", "bonding boxes", "maximum blob" },
+            new[] { src, binary, labelView, rectView, filtered });
     }
 }

--- a/Samples/Samples/ConnectedComponentsSample.cs
+++ b/Samples/Samples/ConnectedComponentsSample.cs
@@ -40,7 +40,6 @@ class ConnectedComponentsSample : ConsoleTestBase
         cc.FilterByBlob(src, filtered, maxBlob);
 
         DisplayHelper.Show(nameof(ConnectedComponentsSample),
-            new[] { "src", "binary", "labels", "bonding boxes", "maximum blob" },
-            new[] { src, binary, labelView, rectView, filtered });
+            ("src", src), ("binary", binary), ("labels", labelView), ("bonding boxes", rectView), ("maximum blob", filtered));
     }
 }

--- a/Samples/Samples/ConnectedComponentsSample.cs
+++ b/Samples/Samples/ConnectedComponentsSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class ConnectedComponentsSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = new Mat(ImagePath.Shapes, ImreadModes.Color);
         using var gray = new Mat();
@@ -39,7 +40,7 @@ class ConnectedComponentsSample : ConsoleTestBase
         var filtered = new Mat();
         cc.FilterByBlob(src, filtered, maxBlob);
 
-        DisplayHelper.Show(nameof(ConnectedComponentsSample),
+        display.Show(
             ("src", src), ("binary", binary), ("labels", labelView), ("bonding boxes", rectView), ("maximum blob", filtered));
     }
 }

--- a/Samples/Samples/DFT.cs
+++ b/Samples/Samples/DFT.cs
@@ -77,6 +77,6 @@ class DFT : ConsoleTestBase
         inverseTransform.ConvertTo(inverseTransform, MatType.CV_8U);
 
         // Show the result
-        DisplayHelper.Show(nameof(DFT), new[] { "Input Image", "Spectrum Magnitude", "Reconstructed by Inverse DFT" }, new[] { img, spectrum, inverseTransform });
+        DisplayHelper.Show(nameof(DFT), ("Input Image", img), ("Spectrum Magnitude", spectrum), ("Reconstructed by Inverse DFT", inverseTransform));
     }
 }

--- a/Samples/Samples/DFT.cs
+++ b/Samples/Samples/DFT.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class DFT : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var img = Cv2.ImRead(ImagePath.Walkman, ImreadModes.Grayscale);
 
@@ -77,6 +78,6 @@ class DFT : ConsoleTestBase
         inverseTransform.ConvertTo(inverseTransform, MatType.CV_8U);
 
         // Show the result
-        DisplayHelper.Show(nameof(DFT), ("Input Image", img), ("Spectrum Magnitude", spectrum), ("Reconstructed by Inverse DFT", inverseTransform));
+        display.Show(("Input Image", img), ("Spectrum Magnitude", spectrum), ("Reconstructed by Inverse DFT", inverseTransform));
     }
 }

--- a/Samples/Samples/DFT.cs
+++ b/Samples/Samples/DFT.cs
@@ -70,18 +70,13 @@ class DFT : ConsoleTestBase
         Cv2.Normalize(spectrum, spectrum, 0, 255, NormTypes.MinMax);
         spectrum.ConvertTo(spectrum, MatType.CV_8U);
 
-        // Show the result
-        Cv2.ImShow("Input Image", img);
-        Cv2.ImShow("Spectrum Magnitude", spectrum);
-
         // calculating the idft
         using var inverseTransform = new Mat();
         Cv2.Dft(dft, inverseTransform, DftFlags.Inverse | DftFlags.RealOutput);
         Cv2.Normalize(inverseTransform, inverseTransform, 0, 255, NormTypes.MinMax);
         inverseTransform.ConvertTo(inverseTransform, MatType.CV_8U);
 
-        Cv2.ImShow("Reconstructed by Inverse DFT", inverseTransform);
-        Cv2.WaitKey();
-        Cv2.DestroyAllWindows();
+        // Show the result
+        DisplayHelper.Show(nameof(DFT), new[] { "Input Image", "Spectrum Magnitude", "Reconstructed by Inverse DFT" }, new[] { img, spectrum, inverseTransform });
     }
 }

--- a/Samples/Samples/DnnSuperresSample.cs
+++ b/Samples/Samples/DnnSuperresSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp.DnnSuperres;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ class DnnSuperresSample : ConsoleTestBase
     // https://github.com/Saafke/FSRCNN_Tensorflow/tree/master/models
     private const string ModelFileName = "Data/Model/FSRCNN_x4.pb";
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var dnn = new DnnSuperResImpl("fsrcnn", 4);
         dnn.ReadModel(ModelFileName);
@@ -19,6 +20,6 @@ class DnnSuperresSample : ConsoleTestBase
         using var dst = new Mat();
         dnn.Upsample(src, dst);
 
-        DisplayHelper.Show(nameof(DnnSuperresSample), ("src", src), ("dst0", dst));
+        display.Show(("src", src), ("dst0", dst));
     }
 }

--- a/Samples/Samples/DnnSuperresSample.cs
+++ b/Samples/Samples/DnnSuperresSample.cs
@@ -19,6 +19,6 @@ class DnnSuperresSample : ConsoleTestBase
         using var dst = new Mat();
         dnn.Upsample(src, dst);
 
-        DisplayHelper.Show(nameof(DnnSuperresSample), new[] { "src", "dst0" }, new[] { src, dst });
+        DisplayHelper.Show(nameof(DnnSuperresSample), ("src", src), ("dst0", dst));
     }
 }

--- a/Samples/Samples/DnnSuperresSample.cs
+++ b/Samples/Samples/DnnSuperresSample.cs
@@ -19,8 +19,6 @@ class DnnSuperresSample : ConsoleTestBase
         using var dst = new Mat();
         dnn.Upsample(src, dst);
 
-        Window.ShowImages(
-            new[] { src, dst },
-            new[] { "src", "dst0" });
+        DisplayHelper.Show(nameof(DnnSuperresSample), new[] { "src", "dst0" }, new[] { src, dst });
     }
 }

--- a/Samples/Samples/DrawBestMatch.cs
+++ b/Samples/Samples/DrawBestMatch.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class DrawBestMatchRectangle : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var img1 = new Mat(ImagePath.Match1, ImreadModes.Color);
         using var img2 = new Mat(ImagePath.Match2, ImreadModes.Color);
@@ -48,6 +49,6 @@ class DrawBestMatchRectangle : ConsoleTestBase
         var drawingPoints = img2BoundsTransformed.Select(p => (Point)p).ToArray();
         Cv2.Polylines(view, new[] { drawingPoints }, true, Scalar.Red, 3);
 
-        DisplayHelper.Show(nameof(DrawBestMatchRectangle), ("view", view));
+        display.Show(("view", view));
     }
 }

--- a/Samples/Samples/DrawBestMatch.cs
+++ b/Samples/Samples/DrawBestMatch.cs
@@ -48,6 +48,6 @@ class DrawBestMatchRectangle : ConsoleTestBase
         var drawingPoints = img2BoundsTransformed.Select(p => (Point)p).ToArray();
         Cv2.Polylines(view, new[] { drawingPoints }, true, Scalar.Red, 3);
 
-        DisplayHelper.Show(nameof(DrawBestMatchRectangle), "view", view);
+        DisplayHelper.Show(nameof(DrawBestMatchRectangle), ("view", view));
     }
 }

--- a/Samples/Samples/DrawBestMatch.cs
+++ b/Samples/Samples/DrawBestMatch.cs
@@ -48,9 +48,6 @@ class DrawBestMatchRectangle : ConsoleTestBase
         var drawingPoints = img2BoundsTransformed.Select(p => (Point)p).ToArray();
         Cv2.Polylines(view, new[] { drawingPoints }, true, Scalar.Red, 3);
 
-        using (new Window("view", view))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(DrawBestMatchRectangle), "view", view);
     }
 }

--- a/Samples/Samples/FASTSample.cs
+++ b/Samples/Samples/FASTSample.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class FASTSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using Mat imgSrc = new Mat(ImagePath.Maltese, ImreadModes.Color);
         using Mat imgGray = new Mat();
@@ -23,6 +24,6 @@ class FASTSample : ConsoleTestBase
             Cv2.Circle(imgDst, (Point)kp.Pt, 3, Scalar.Red, -1, LineTypes.AntiAlias, 0);
         }
 
-        DisplayHelper.Show(nameof(FASTSample), ("FAST", imgDst));
+        display.Show(("FAST", imgDst));
     }
 }

--- a/Samples/Samples/FASTSample.cs
+++ b/Samples/Samples/FASTSample.cs
@@ -23,8 +23,6 @@ class FASTSample : ConsoleTestBase
             Cv2.Circle(imgDst, (Point)kp.Pt, 3, Scalar.Red, -1, LineTypes.AntiAlias, 0);
         }
 
-        Cv2.ImShow("FAST", imgDst);
-        Cv2.WaitKey(0);
-        Cv2.DestroyAllWindows();
+        DisplayHelper.Show(nameof(FASTSample), "FAST", imgDst);
     }
 }

--- a/Samples/Samples/FASTSample.cs
+++ b/Samples/Samples/FASTSample.cs
@@ -23,6 +23,6 @@ class FASTSample : ConsoleTestBase
             Cv2.Circle(imgDst, (Point)kp.Pt, 3, Scalar.Red, -1, LineTypes.AntiAlias, 0);
         }
 
-        DisplayHelper.Show(nameof(FASTSample), "FAST", imgDst);
+        DisplayHelper.Show(nameof(FASTSample), ("FAST", imgDst));
     }
 }

--- a/Samples/Samples/FREAKSample.cs
+++ b/Samples/Samples/FREAKSample.cs
@@ -42,6 +42,6 @@ class FREAKSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(FREAKSample), "FREAK", dst);
+        DisplayHelper.Show(nameof(FREAKSample), ("FREAK", dst));
     }
 }

--- a/Samples/Samples/FREAKSample.cs
+++ b/Samples/Samples/FREAKSample.cs
@@ -42,9 +42,6 @@ class FREAKSample : ConsoleTestBase
             }
         }
 
-        using (new Window("FREAK", dst))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(FREAKSample), "FREAK", dst);
     }
 }

--- a/Samples/Samples/FREAKSample.cs
+++ b/Samples/Samples/FREAKSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class FREAKSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var gray = new Mat(ImagePath.Penguin2, ImreadModes.Grayscale);
         using var dst = new Mat(ImagePath.Penguin2, ImreadModes.Color);
@@ -42,6 +43,6 @@ class FREAKSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(FREAKSample), ("FREAK", dst));
+        display.Show(("FREAK", dst));
     }
 }

--- a/Samples/Samples/FaceDetection.cs
+++ b/Samples/Samples/FaceDetection.cs
@@ -20,10 +20,7 @@ class FaceDetection : ConsoleTestBase
         Mat haarResult = DetectFace(haarCascade);
         Mat lbpResult = DetectFace(lbpCascade);
 
-        Cv2.ImShow("Faces by Haar", haarResult);
-        Cv2.ImShow("Faces by LBP", lbpResult);
-        Cv2.WaitKey(0);
-        Cv2.DestroyAllWindows();
+        DisplayHelper.Show(nameof(FaceDetection), new[] { "Faces by Haar", "Faces by LBP" }, new[] { haarResult, lbpResult });
     }
 
     /// <summary>

--- a/Samples/Samples/FaceDetection.cs
+++ b/Samples/Samples/FaceDetection.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class FaceDetection : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         // Load the cascades
         using var haarCascade = new CascadeClassifier(TextPath.HaarCascade);
@@ -20,7 +21,7 @@ class FaceDetection : ConsoleTestBase
         Mat haarResult = DetectFace(haarCascade);
         Mat lbpResult = DetectFace(lbpCascade);
 
-        DisplayHelper.Show(nameof(FaceDetection), ("Faces by Haar", haarResult), ("Faces by LBP", lbpResult));
+        display.Show(("Faces by Haar", haarResult), ("Faces by LBP", lbpResult));
     }
 
     /// <summary>

--- a/Samples/Samples/FaceDetection.cs
+++ b/Samples/Samples/FaceDetection.cs
@@ -20,7 +20,7 @@ class FaceDetection : ConsoleTestBase
         Mat haarResult = DetectFace(haarCascade);
         Mat lbpResult = DetectFace(lbpCascade);
 
-        DisplayHelper.Show(nameof(FaceDetection), new[] { "Faces by Haar", "Faces by LBP" }, new[] { haarResult, lbpResult });
+        DisplayHelper.Show(nameof(FaceDetection), ("Faces by Haar", haarResult), ("Faces by LBP", lbpResult));
     }
 
     /// <summary>

--- a/Samples/Samples/FlannSample.cs
+++ b/Samples/Samples/FlannSample.cs
@@ -50,6 +50,5 @@ class FlannSample : ConsoleTestBase
                 Console.WriteLine();
             }
         }
-        Console.Read();
     }
 }

--- a/Samples/Samples/FlannSample.cs
+++ b/Samples/Samples/FlannSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using OpenCvSharp.Flann;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class FlannSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         Console.WriteLine("===== FlannTest =====");
 

--- a/Samples/Samples/GrabCutSample.cs
+++ b/Samples/Samples/GrabCutSample.cs
@@ -1,6 +1,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// <remarks>https://docs.opencv.org/4.x/d8/d83/tutorial_py_grabcut.html</remarks>
 class GrabCutSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = new Mat(ImagePath.Fruits, ImreadModes.Color);
 
@@ -33,6 +34,6 @@ class GrabCutSample : ConsoleTestBase
         using var rectView = src.Clone();
         Cv2.Rectangle(rectView, rect, Scalar.Red, 2);
 
-        DisplayHelper.Show(nameof(GrabCutSample), ("initial rect", rectView), ("foreground mask", fgMask), ("extracted foreground", foreground));
+        display.Show(("initial rect", rectView), ("foreground mask", fgMask), ("extracted foreground", foreground));
     }
 }

--- a/Samples/Samples/GrabCutSample.cs
+++ b/Samples/Samples/GrabCutSample.cs
@@ -33,6 +33,6 @@ class GrabCutSample : ConsoleTestBase
         using var rectView = src.Clone();
         Cv2.Rectangle(rectView, rect, Scalar.Red, 2);
 
-        DisplayHelper.Show(nameof(GrabCutSample), new[] { "initial rect", "foreground mask", "extracted foreground" }, new[] { rectView, fgMask, foreground });
+        DisplayHelper.Show(nameof(GrabCutSample), ("initial rect", rectView), ("foreground mask", fgMask), ("extracted foreground", foreground));
     }
 }

--- a/Samples/Samples/GrabCutSample.cs
+++ b/Samples/Samples/GrabCutSample.cs
@@ -33,8 +33,6 @@ class GrabCutSample : ConsoleTestBase
         using var rectView = src.Clone();
         Cv2.Rectangle(rectView, rect, Scalar.Red, 2);
 
-        Window.ShowImages(
-            new[] { rectView, fgMask, foreground },
-            new[] { "initial rect", "foreground mask", "extracted foreground" });
+        DisplayHelper.Show(nameof(GrabCutSample), new[] { "initial rect", "foreground mask", "extracted foreground" }, new[] { rectView, fgMask, foreground });
     }
 }

--- a/Samples/Samples/HOGSample.cs
+++ b/Samples/Samples/HOGSample.cs
@@ -50,8 +50,6 @@ internal class HOGSample : ConsoleTestBase
             Cv2.Rectangle(img, r.TopLeft, r.BottomRight, Scalar.Red, 3);
         }
 
-        using var window = new Window("people detector", img, WindowFlags.Normal);
-        window.SetProperty(WindowPropertyFlags.Fullscreen, 1);
-        Cv2.WaitKey(0);
+        DisplayHelper.Show(nameof(HOGSample), "people detector", img);
     }
 }

--- a/Samples/Samples/HOGSample.cs
+++ b/Samples/Samples/HOGSample.cs
@@ -50,6 +50,6 @@ internal class HOGSample : ConsoleTestBase
             Cv2.Rectangle(img, r.TopLeft, r.BottomRight, Scalar.Red, 3);
         }
 
-        DisplayHelper.Show(nameof(HOGSample), "people detector", img);
+        DisplayHelper.Show(nameof(HOGSample), ("people detector", img));
     }
 }

--- a/Samples/Samples/HOGSample.cs
+++ b/Samples/Samples/HOGSample.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -15,7 +16,7 @@ internal class HOGSample : ConsoleTestBase
     {
     }
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var img = Cv2.ImRead(ImagePath.Asahiyama, ImreadModes.Color);
 
@@ -50,6 +51,6 @@ internal class HOGSample : ConsoleTestBase
             Cv2.Rectangle(img, r.TopLeft, r.BottomRight, Scalar.Red, 3);
         }
 
-        DisplayHelper.Show(nameof(HOGSample), ("people detector", img));
+        display.Show(("people detector", img));
     }
 }

--- a/Samples/Samples/HistSample.cs
+++ b/Samples/Samples/HistSample.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class HistSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Balloon, ImreadModes.Grayscale);
 
@@ -48,6 +49,6 @@ class HistSample : ConsoleTestBase
                 -1);
         }
 
-        DisplayHelper.Show(nameof(HistSample), ("Image", src), ("Histogram", render));
+        display.Show(("Image", src), ("Histogram", render));
     }
 }

--- a/Samples/Samples/HistSample.cs
+++ b/Samples/Samples/HistSample.cs
@@ -48,10 +48,6 @@ class HistSample : ConsoleTestBase
                 -1);
         }
 
-        using (new Window("Image", src, WindowFlags.AutoSize | WindowFlags.FreeRatio))
-        using (new Window("Histogram", render, WindowFlags.AutoSize | WindowFlags.FreeRatio))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(HistSample), new[] { "Image", "Histogram" }, new[] { src, render });
     }
 }

--- a/Samples/Samples/HistSample.cs
+++ b/Samples/Samples/HistSample.cs
@@ -48,6 +48,6 @@ class HistSample : ConsoleTestBase
                 -1);
         }
 
-        DisplayHelper.Show(nameof(HistSample), new[] { "Image", "Histogram" }, new[] { src, render });
+        DisplayHelper.Show(nameof(HistSample), ("Image", src), ("Histogram", render));
     }
 }

--- a/Samples/Samples/HoughLinesSample.cs
+++ b/Samples/Samples/HoughLinesSample.cs
@@ -53,6 +53,6 @@ class HoughLinesSample : ConsoleTestBase
         }
 
         // (5) Show results
-        DisplayHelper.Show(nameof(HoughLinesSample), new[] { "Hough_line_standard", "Hough_line_probabilistic" }, new[] { imgStd, imgProb });
+        DisplayHelper.Show(nameof(HoughLinesSample), ("Hough_line_standard", imgStd), ("Hough_line_probabilistic", imgProb));
     }
 }

--- a/Samples/Samples/HoughLinesSample.cs
+++ b/Samples/Samples/HoughLinesSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -11,15 +12,15 @@ namespace SamplesCore;
 /// <remarks>http://opencv.jp/sample/special_transforms.html#hough_line</remarks>
 class HoughLinesSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        SampleCpp();
+        SampleCpp(display);
     }
 
     /// <summary>
     /// sample of new C++ style wrapper
     /// </summary>
-    private void SampleCpp()
+    private void SampleCpp(DisplayHelper display)
     {
         // (1) Load the image
         using var imgGray = new Mat(ImagePath.Goryokaku, ImreadModes.Grayscale);
@@ -53,6 +54,6 @@ class HoughLinesSample : ConsoleTestBase
         }
 
         // (5) Show results
-        DisplayHelper.Show(nameof(HoughLinesSample), ("Hough_line_standard", imgStd), ("Hough_line_probabilistic", imgProb));
+        display.Show(("Hough_line_standard", imgStd), ("Hough_line_probabilistic", imgProb));
     }
 }

--- a/Samples/Samples/HoughLinesSample.cs
+++ b/Samples/Samples/HoughLinesSample.cs
@@ -53,10 +53,6 @@ class HoughLinesSample : ConsoleTestBase
         }
 
         // (5) Show results
-        using (new Window("Hough_line_standard", imgStd, WindowFlags.AutoSize))
-        using (new Window("Hough_line_probabilistic", imgProb, WindowFlags.AutoSize))
-        {
-            Window.WaitKey(0);
-        }
+        DisplayHelper.Show(nameof(HoughLinesSample), new[] { "Hough_line_standard", "Hough_line_probabilistic" }, new[] { imgStd, imgProb });
     }
 }

--- a/Samples/Samples/InpaintSample.cs
+++ b/Samples/Samples/InpaintSample.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
@@ -16,13 +15,18 @@ public class InpaintSample : ConsoleTestBase
     {
         // cvInpaint
 
+        if (DisplayHelper.IsHeadless)
+        {
+            PrintWarning("Skipping: this sample requires interactively painting a mask with the mouse and cannot be meaningfully verified headlessly.");
+            return;
+        }
+
         Console.WriteLine(
             "Hot keys: \n" +
             "\tESC - quit the program\n" +
             "\tr - restore the original image\n" +
             "\ti or ENTER - run inpainting algorithm\n" +
-            "\t\t(before running it, paint something on the image)\n" +
-            "\ts - save the original image, mask image, original+mask image and inpainted image to desktop."
+            "\t\t(before running it, paint something on the image)"
         );
 
         using var img0 = Cv2.ImRead(ImagePath.Fruits, ImreadModes.AnyDepth | ImreadModes.AnyColor);
@@ -79,13 +83,6 @@ public class InpaintSample : ConsoleTestBase
                         Cv2.Inpaint(img, inpaintMask, inpainted, 3, InpaintTypes.NS);
                         wInpaint2 ??= new Window("inpainted image (algorithm by Navier-Strokes)", WindowFlags.AutoSize);
                         wInpaint2.ShowImage(inpainted);
-                        break;
-                    case 's': // save images
-                        string desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-                        Cv2.ImWrite(Path.Combine(desktop, "original.png"), img0);
-                        Cv2.ImWrite(Path.Combine(desktop, "mask.png"), inpaintMask);
-                        Cv2.ImWrite(Path.Combine(desktop, "original+mask.png"), img);
-                        Cv2.ImWrite(Path.Combine(desktop, "inpainted.png"), inpainted);
                         break;
                 }
             }

--- a/Samples/Samples/InpaintSample.cs
+++ b/Samples/Samples/InpaintSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -11,11 +12,11 @@ namespace SamplesCore;
 /// <remarks>http://opencv.jp/sample/special_transforms.html#inpaint</remarks>
 public class InpaintSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         // cvInpaint
 
-        if (DisplayHelper.IsHeadless)
+        if (display.IsHeadless)
         {
             PrintWarning("Skipping: this sample requires interactively painting a mask with the mouse and cannot be meaningfully verified headlessly.");
             return;

--- a/Samples/Samples/KAZESample.cs
+++ b/Samples/Samples/KAZESample.cs
@@ -31,11 +31,9 @@ internal class KAZESample : ConsoleTestBase
         Cv2.DrawKeypoints(gray, kazeKeyPoints, dstKaze);
         Cv2.DrawKeypoints(gray, akazeKeyPoints, dstAkaze);
 
-        using (new Window(String.Format("KAZE [{0:F2}ms]", kazeTime.TotalMilliseconds), dstKaze))
-        using (new Window(String.Format("AKAZE [{0:F2}ms]", akazeTime.TotalMilliseconds), dstAkaze))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(KAZESample),
+            new[] { String.Format("KAZE [{0:F2}ms]", kazeTime.TotalMilliseconds), String.Format("AKAZE [{0:F2}ms]", akazeTime.TotalMilliseconds) },
+            new[] { dstKaze, dstAkaze });
     }
 
     private TimeSpan MeasureTime(Action action)

--- a/Samples/Samples/KAZESample.cs
+++ b/Samples/Samples/KAZESample.cs
@@ -32,8 +32,8 @@ internal class KAZESample : ConsoleTestBase
         Cv2.DrawKeypoints(gray, akazeKeyPoints, dstAkaze);
 
         DisplayHelper.Show(nameof(KAZESample),
-            new[] { String.Format("KAZE [{0:F2}ms]", kazeTime.TotalMilliseconds), String.Format("AKAZE [{0:F2}ms]", akazeTime.TotalMilliseconds) },
-            new[] { dstKaze, dstAkaze });
+            (String.Format("KAZE [{0:F2}ms]", kazeTime.TotalMilliseconds), dstKaze),
+            (String.Format("AKAZE [{0:F2}ms]", akazeTime.TotalMilliseconds), dstAkaze));
     }
 
     private TimeSpan MeasureTime(Action action)

--- a/Samples/Samples/KAZESample.cs
+++ b/Samples/Samples/KAZESample.cs
@@ -4,6 +4,7 @@ using OpenCvSharp;
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -12,7 +13,7 @@ namespace SamplesCore;
 /// </summary>
 internal class KAZESample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         var gray = new Mat(ImagePath.Cat, ImreadModes.Grayscale);
         var kaze = KAZE.Create();
@@ -31,7 +32,7 @@ internal class KAZESample : ConsoleTestBase
         Cv2.DrawKeypoints(gray, kazeKeyPoints, dstKaze);
         Cv2.DrawKeypoints(gray, akazeKeyPoints, dstAkaze);
 
-        DisplayHelper.Show(nameof(KAZESample),
+        display.Show(
             (String.Format("KAZE [{0:F2}ms]", kazeTime.TotalMilliseconds), dstKaze),
             (String.Format("AKAZE [{0:F2}ms]", akazeTime.TotalMilliseconds), dstAkaze));
     }

--- a/Samples/Samples/KAZESample2.cs
+++ b/Samples/Samples/KAZESample2.cs
@@ -99,8 +99,7 @@ class KAZESample2 : ConsoleTestBase
                 //Cv2.Line(img3, scene_corners[2] + new Point2d(img1.Cols, 0), scene_corners[3] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
                 //Cv2.Line(img3, scene_corners[3] + new Point2d(img1.Cols, 0), scene_corners[0] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
 
-                Cv2.ImWrite("Kaze_Output.png", img3);
-                Window.ShowImages(img3);
+                DisplayHelper.Show(nameof(KAZESample2), "img3", img3);
             }
         }
     }

--- a/Samples/Samples/KAZESample2.cs
+++ b/Samples/Samples/KAZESample2.cs
@@ -99,7 +99,7 @@ class KAZESample2 : ConsoleTestBase
                 //Cv2.Line(img3, scene_corners[2] + new Point2d(img1.Cols, 0), scene_corners[3] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
                 //Cv2.Line(img3, scene_corners[3] + new Point2d(img1.Cols, 0), scene_corners[0] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
 
-                DisplayHelper.Show(nameof(KAZESample2), "img3", img3);
+                DisplayHelper.Show(nameof(KAZESample2), ("img3", img3));
             }
         }
     }

--- a/Samples/Samples/KAZESample2.cs
+++ b/Samples/Samples/KAZESample2.cs
@@ -6,6 +6,7 @@ using OpenCvSharp;
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -19,7 +20,7 @@ class KAZESample2 : ConsoleTestBase
         return new Point2d(((int)pf.X), ((int)pf.Y));
     }
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var img1 = new Mat(ImagePath.SurfBox);
         using var img2 = new Mat(ImagePath.SurfBoxinscene);
@@ -99,7 +100,7 @@ class KAZESample2 : ConsoleTestBase
                 //Cv2.Line(img3, scene_corners[2] + new Point2d(img1.Cols, 0), scene_corners[3] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
                 //Cv2.Line(img3, scene_corners[3] + new Point2d(img1.Cols, 0), scene_corners[0] + new Point2d(img1.Cols, 0), Scalar.LimeGreen);
 
-                DisplayHelper.Show(nameof(KAZESample2), ("img3", img3));
+                display.Show(("img3", img3));
             }
         }
     }

--- a/Samples/Samples/MDS.cs
+++ b/Samples/Samples/MDS.cs
@@ -106,7 +106,7 @@ class MDS : ConsoleTestBase
                 var textPos = new Point(x + 5, y + 10);
                 Cv2.PutText(img, CityNames[c], textPos, HersheyFonts.HersheySimplex, 0.5, Scalar.White);
             }
-            DisplayHelper.Show(nameof(MDS), "City Location Estimation", img);
+            DisplayHelper.Show(nameof(MDS), ("City Location Estimation", img));
         }
     }
 

--- a/Samples/Samples/MDS.cs
+++ b/Samples/Samples/MDS.cs
@@ -94,7 +94,6 @@ class MDS : ConsoleTestBase
 
         // opens a window
         using (Mat img = Mat.Zeros(600, 800, MatType.CV_8UC3))
-        using (var window = new Window("City Location Estimation"))
         {
             var resultRows = result.AsRows<double>();
             for (int c = 0; c < size; c++)
@@ -107,8 +106,7 @@ class MDS : ConsoleTestBase
                 var textPos = new Point(x + 5, y + 10);
                 Cv2.PutText(img, CityNames[c], textPos, HersheyFonts.HersheySimplex, 0.5, Scalar.White);
             }
-            window.Image = img;
-            Cv2.WaitKey();
+            DisplayHelper.Show(nameof(MDS), "City Location Estimation", img);
         }
     }
 

--- a/Samples/Samples/MDS.cs
+++ b/Samples/Samples/MDS.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using OpenCvSharp;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -42,7 +43,7 @@ class MDS : ConsoleTestBase
     /// <summary>
     /// Classical Multidimensional Scaling
     /// </summary>
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         // creates distance matrix
         int size = CityDistance.GetLength(0);
@@ -106,7 +107,7 @@ class MDS : ConsoleTestBase
                 var textPos = new Point(x + 5, y + 10);
                 Cv2.PutText(img, CityNames[c], textPos, HersheyFonts.HersheySimplex, 0.5, Scalar.White);
             }
-            DisplayHelper.Show(nameof(MDS), ("City Location Estimation", img));
+            display.Show(("City Location Estimation", img));
         }
     }
 

--- a/Samples/Samples/MSERSample.cs
+++ b/Samples/Samples/MSERSample.cs
@@ -18,7 +18,7 @@ class MSERSample : ConsoleTestBase
 
         CppStyleMSER(gray, dst);  // C++ style
 
-        DisplayHelper.Show(nameof(MSERSample), new[] { "MSER src", "MSER gray", "MSER dst" }, new[] { src, gray, dst });
+        DisplayHelper.Show(nameof(MSERSample), ("MSER src", src), ("MSER gray", gray), ("MSER dst", dst));
     }
 
     /// <summary>

--- a/Samples/Samples/MSERSample.cs
+++ b/Samples/Samples/MSERSample.cs
@@ -18,12 +18,7 @@ class MSERSample : ConsoleTestBase
 
         CppStyleMSER(gray, dst);  // C++ style
 
-        using (new Window("MSER src", src))
-        using (new Window("MSER gray", gray))
-        using (new Window("MSER dst", dst))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(MSERSample), new[] { "MSER src", "MSER gray", "MSER dst" }, new[] { src, gray, dst });
     }
 
     /// <summary>

--- a/Samples/Samples/MSERSample.cs
+++ b/Samples/Samples/MSERSample.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class MSERSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using Mat src = new Mat(ImagePath.Distortion, ImreadModes.Color);
         using Mat gray = new Mat();
@@ -18,7 +19,7 @@ class MSERSample : ConsoleTestBase
 
         CppStyleMSER(gray, dst);  // C++ style
 
-        DisplayHelper.Show(nameof(MSERSample), ("MSER src", src), ("MSER gray", gray), ("MSER dst", dst));
+        display.Show(("MSER src", src), ("MSER gray", gray), ("MSER dst", dst));
     }
 
     /// <summary>

--- a/Samples/Samples/MatOperations.cs
+++ b/Samples/Samples/MatOperations.cs
@@ -41,7 +41,7 @@ class MatOperations : ConsoleTestBase
         part = src.SubMat(50, 100, 400, 450);
         part.SetTo(128);
 
-        DisplayHelper.Show(nameof(MatOperations), "SubMat", src);
+        DisplayHelper.Show(nameof(MatOperations), ("SubMat", src));
 
         part.Dispose();
     }
@@ -63,7 +63,7 @@ class MatOperations : ConsoleTestBase
             src.ColRange(100, 200),
             new Size(7, 7), 20);
 
-        DisplayHelper.Show(nameof(MatOperations), "RowColRangeOperation", src);
+        DisplayHelper.Show(nameof(MatOperations), ("RowColRangeOperation", src));
     }
 
     /// <summary>
@@ -97,6 +97,6 @@ class MatOperations : ConsoleTestBase
             rowRange.SetTo(new Scalar(0, 0, 255));
         }
 
-        DisplayHelper.Show(nameof(MatOperations), "RowColOperation", src);
+        DisplayHelper.Show(nameof(MatOperations), ("RowColOperation", src));
     }
 }

--- a/Samples/Samples/MatOperations.cs
+++ b/Samples/Samples/MatOperations.cs
@@ -41,10 +41,7 @@ class MatOperations : ConsoleTestBase
         part = src.SubMat(50, 100, 400, 450);
         part.SetTo(128);
 
-        using (new Window("SubMat", src))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(MatOperations), "SubMat", src);
 
         part.Dispose();
     }
@@ -66,10 +63,7 @@ class MatOperations : ConsoleTestBase
             src.ColRange(100, 200),
             new Size(7, 7), 20);
 
-        using (new Window("RowColRangeOperation", src))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(MatOperations), "RowColRangeOperation", src);
     }
 
     /// <summary>
@@ -103,9 +97,6 @@ class MatOperations : ConsoleTestBase
             rowRange.SetTo(new Scalar(0, 0, 255));
         }
 
-        using (new Window("RowColOperation", src))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(MatOperations), "RowColOperation", src);
     }
 }

--- a/Samples/Samples/MatOperations.cs
+++ b/Samples/Samples/MatOperations.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,17 +11,17 @@ namespace SamplesCore;
 /// </summary>
 class MatOperations : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        SubMat();
-        RowColRangeOperation();
-        RowColOperation();
+        SubMat(display);
+        RowColRangeOperation(display);
+        RowColOperation(display);
     }
 
     /// <summary>
     /// Submatrix operations
     /// </summary>
-    private static void SubMat()
+    private static void SubMat(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Fruits);
 
@@ -41,7 +42,7 @@ class MatOperations : ConsoleTestBase
         part = src.SubMat(50, 100, 400, 450);
         part.SetTo(128);
 
-        DisplayHelper.Show(nameof(MatOperations), ("SubMat", src));
+        display.Show(("SubMat", src));
 
         part.Dispose();
     }
@@ -49,7 +50,7 @@ class MatOperations : ConsoleTestBase
     /// <summary>
     /// Submatrix operations
     /// </summary>
-    private static void RowColRangeOperation()
+    private static void RowColRangeOperation(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Fruits);
 
@@ -63,13 +64,13 @@ class MatOperations : ConsoleTestBase
             src.ColRange(100, 200),
             new Size(7, 7), 20);
 
-        DisplayHelper.Show(nameof(MatOperations), ("RowColRangeOperation", src));
+        display.Show(("RowColRangeOperation", src));
     }
 
     /// <summary>
     /// Submatrix expression operations
     /// </summary>
-    private static void RowColOperation()
+    private static void RowColOperation(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Fruits);
 
@@ -97,6 +98,6 @@ class MatOperations : ConsoleTestBase
             rowRange.SetTo(new Scalar(0, 0, 255));
         }
 
-        DisplayHelper.Show(nameof(MatOperations), ("RowColOperation", src));
+        display.Show(("RowColOperation", src));
     }
 }

--- a/Samples/Samples/MergeSplitSample.cs
+++ b/Samples/Samples/MergeSplitSample.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class MergeSplitSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         // Split/Merge Test
         {
@@ -18,7 +19,7 @@ class MergeSplitSample : ConsoleTestBase
             // Split each plane
             Cv2.Split(src, out var planes);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), ("planes 0", planes[0]), ("planes 1", planes[1]), ("planes 2", planes[2]));
+            display.Show(("planes 0", planes[0]), ("planes 1", planes[1]), ("planes 2", planes[2]));
 
             // Invert G plane
             Cv2.BitwiseNot(planes[1], planes[1]);
@@ -27,7 +28,7 @@ class MergeSplitSample : ConsoleTestBase
             using var merged = new Mat();
             Cv2.Merge(planes, merged);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), ("src", src), ("merged", merged));
+            display.Show(("src", src), ("merged", merged));
         }
 
         // MixChannels Test
@@ -43,7 +44,7 @@ class MergeSplitSample : ConsoleTestBase
             int[] fromTo = { 0, 2, 1, 1, 2, 0, 3, 3 };
             Cv2.MixChannels(input, output, fromTo);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), ("rgba", rgba), ("bgr", bgr), ("alpha", alpha));
+            display.Show(("rgba", rgba), ("bgr", bgr), ("alpha", alpha));
         }
     }
 }

--- a/Samples/Samples/MergeSplitSample.cs
+++ b/Samples/Samples/MergeSplitSample.cs
@@ -18,11 +18,7 @@ class MergeSplitSample : ConsoleTestBase
             // Split each plane
             Cv2.Split(src, out var planes);
 
-            Cv2.ImShow("planes 0", planes[0]);
-            Cv2.ImShow("planes 1", planes[1]);
-            Cv2.ImShow("planes 2", planes[2]);
-            Cv2.WaitKey();
-            Cv2.DestroyAllWindows();
+            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "planes 0", "planes 1", "planes 2" }, new[] { planes[0], planes[1], planes[2] });
 
             // Invert G plane
             Cv2.BitwiseNot(planes[1], planes[1]);
@@ -31,10 +27,7 @@ class MergeSplitSample : ConsoleTestBase
             using var merged = new Mat();
             Cv2.Merge(planes, merged);
 
-            Cv2.ImShow("src", src);
-            Cv2.ImShow("merged", merged);
-            Cv2.WaitKey();
-            Cv2.DestroyAllWindows();
+            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "src", "merged" }, new[] { src, merged });
         }
 
         // MixChannels Test
@@ -50,11 +43,7 @@ class MergeSplitSample : ConsoleTestBase
             int[] fromTo = { 0, 2, 1, 1, 2, 0, 3, 3 };
             Cv2.MixChannels(input, output, fromTo);
 
-            Cv2.ImShow("rgba", rgba);
-            Cv2.ImShow("bgr", bgr);
-            Cv2.ImShow("alpha", alpha);
-            Cv2.WaitKey();
-            Cv2.DestroyAllWindows();
+            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "rgba", "bgr", "alpha" }, new[] { rgba, bgr, alpha });
         }
     }
 }

--- a/Samples/Samples/MergeSplitSample.cs
+++ b/Samples/Samples/MergeSplitSample.cs
@@ -18,7 +18,7 @@ class MergeSplitSample : ConsoleTestBase
             // Split each plane
             Cv2.Split(src, out var planes);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "planes 0", "planes 1", "planes 2" }, new[] { planes[0], planes[1], planes[2] });
+            DisplayHelper.Show(nameof(MergeSplitSample), ("planes 0", planes[0]), ("planes 1", planes[1]), ("planes 2", planes[2]));
 
             // Invert G plane
             Cv2.BitwiseNot(planes[1], planes[1]);
@@ -27,7 +27,7 @@ class MergeSplitSample : ConsoleTestBase
             using var merged = new Mat();
             Cv2.Merge(planes, merged);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "src", "merged" }, new[] { src, merged });
+            DisplayHelper.Show(nameof(MergeSplitSample), ("src", src), ("merged", merged));
         }
 
         // MixChannels Test
@@ -43,7 +43,7 @@ class MergeSplitSample : ConsoleTestBase
             int[] fromTo = { 0, 2, 1, 1, 2, 0, 3, 3 };
             Cv2.MixChannels(input, output, fromTo);
 
-            DisplayHelper.Show(nameof(MergeSplitSample), new[] { "rgba", "bgr", "alpha" }, new[] { rgba, bgr, alpha });
+            DisplayHelper.Show(nameof(MergeSplitSample), ("rgba", rgba), ("bgr", bgr), ("alpha", alpha));
         }
     }
 }

--- a/Samples/Samples/MorphologySample.cs
+++ b/Samples/Samples/MorphologySample.cs
@@ -26,10 +26,6 @@ class MorphologySample : ConsoleTestBase
         // + kernel
         Cv2.Dilate(binary, dilate2, kernel);
 
-        Cv2.ImShow("binary", binary);
-        Cv2.ImShow("dilate (kernel = null)", dilate1);
-        Cv2.ImShow("dilate (kernel = +)", dilate2);
-        Cv2.WaitKey(0);
-        Cv2.DestroyAllWindows();
+        DisplayHelper.Show(nameof(MorphologySample), new[] { "binary", "dilate (kernel = null)", "dilate (kernel = +)" }, new[] { binary, dilate1, dilate2 });
     }
 }

--- a/Samples/Samples/MorphologySample.cs
+++ b/Samples/Samples/MorphologySample.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class MorphologySample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var gray = new Mat(ImagePath.Cake, ImreadModes.Grayscale);
         using var binary = new Mat();
@@ -26,6 +27,6 @@ class MorphologySample : ConsoleTestBase
         // + kernel
         Cv2.Dilate(binary, dilate2, kernel);
 
-        DisplayHelper.Show(nameof(MorphologySample), ("binary", binary), ("dilate (kernel = null)", dilate1), ("dilate (kernel = +)", dilate2));
+        display.Show(("binary", binary), ("dilate (kernel = null)", dilate1), ("dilate (kernel = +)", dilate2));
     }
 }

--- a/Samples/Samples/MorphologySample.cs
+++ b/Samples/Samples/MorphologySample.cs
@@ -26,6 +26,6 @@ class MorphologySample : ConsoleTestBase
         // + kernel
         Cv2.Dilate(binary, dilate2, kernel);
 
-        DisplayHelper.Show(nameof(MorphologySample), new[] { "binary", "dilate (kernel = null)", "dilate (kernel = +)" }, new[] { binary, dilate1, dilate2 });
+        DisplayHelper.Show(nameof(MorphologySample), ("binary", binary), ("dilate (kernel = null)", dilate1), ("dilate (kernel = +)", dilate2));
     }
 }

--- a/Samples/Samples/NormalArrayOperations.cs
+++ b/Samples/Samples/NormalArrayOperations.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OpenCvSharp;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class NormalArrayOperations : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         Threshold1();
         Threshold2();

--- a/Samples/Samples/ObjectTrackingSample.cs
+++ b/Samples/Samples/ObjectTrackingSample.cs
@@ -29,7 +29,6 @@ class ObjectTrackingSample : ConsoleTestBase
         Rect box = InitialBox;
         tracker.Init(frame, box);
 
-        using var window = new Window("CSRT object tracking");
         while (true)
         {
             bool found = tracker.Update(frame, ref box);
@@ -38,8 +37,8 @@ class ObjectTrackingSample : ConsoleTestBase
             {
                 Cv2.Rectangle(view, box, Scalar.Red, 2);
             }
-            window.Image = view;
-            Cv2.WaitKey(30);
+            if (!DisplayHelper.ShowFrame(nameof(ObjectTrackingSample), "CSRT object tracking", view, 30))
+                break;
 
             capture.Read(frame);
             if (frame.Empty())

--- a/Samples/Samples/ObjectTrackingSample.cs
+++ b/Samples/Samples/ObjectTrackingSample.cs
@@ -2,6 +2,7 @@ using OpenCvSharp;
 using OpenCvSharp.Tracking;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -14,7 +15,7 @@ class ObjectTrackingSample : ConsoleTestBase
     // Bounding box around the puppy in the first frame
     private static readonly Rect InitialBox = new(300, 150, 180, 200);
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var capture = new VideoCapture(MoviePath.Hara);
         if (!capture.IsOpened())
@@ -37,7 +38,7 @@ class ObjectTrackingSample : ConsoleTestBase
             {
                 Cv2.Rectangle(view, box, Scalar.Red, 2);
             }
-            if (!DisplayHelper.ShowFrame(nameof(ObjectTrackingSample), ("CSRT object tracking", view)))
+            if (!display.ShowFrame(("CSRT object tracking", view)))
                 break;
 
             capture.Read(frame);

--- a/Samples/Samples/ObjectTrackingSample.cs
+++ b/Samples/Samples/ObjectTrackingSample.cs
@@ -37,7 +37,7 @@ class ObjectTrackingSample : ConsoleTestBase
             {
                 Cv2.Rectangle(view, box, Scalar.Red, 2);
             }
-            if (!DisplayHelper.ShowFrame(nameof(ObjectTrackingSample), "CSRT object tracking", view, 30))
+            if (!DisplayHelper.ShowFrame(nameof(ObjectTrackingSample), ("CSRT object tracking", view)))
                 break;
 
             capture.Read(frame);

--- a/Samples/Samples/OpticalFlowSample.cs
+++ b/Samples/Samples/OpticalFlowSample.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -16,7 +17,7 @@ class OpticalFlowSample : ConsoleTestBase
     private static readonly TermCriteria Criteria =
         new(CriteriaTypes.Eps | CriteriaTypes.Count, 10, 0.03);
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var capture = new VideoCapture(MoviePath.Bach);
         if (!capture.IsOpened())
@@ -63,7 +64,7 @@ class OpticalFlowSample : ConsoleTestBase
             }
             Cv2.Add(view, mask, view);
 
-            if (!DisplayHelper.ShowFrame(nameof(OpticalFlowSample), ("Lucas-Kanade optical flow", view)))
+            if (!display.ShowFrame(("Lucas-Kanade optical flow", view)))
                 break;
 
             gray.CopyTo(prevGray);

--- a/Samples/Samples/OpticalFlowSample.cs
+++ b/Samples/Samples/OpticalFlowSample.cs
@@ -37,7 +37,6 @@ class OpticalFlowSample : ConsoleTestBase
         var colors = points.Select(_ => new Scalar(random.Next(256), random.Next(256), random.Next(256))).ToArray();
 
         using Mat mask = Mat.Zeros(prevGray.Rows, prevGray.Cols, MatType.CV_8UC3);
-        using var window = new Window("Lucas-Kanade optical flow");
         using var frame = new Mat();
         using var gray = new Mat();
 
@@ -64,8 +63,8 @@ class OpticalFlowSample : ConsoleTestBase
             }
             Cv2.Add(view, mask, view);
 
-            window.Image = view;
-            Cv2.WaitKey(30);
+            if (!DisplayHelper.ShowFrame(nameof(OpticalFlowSample), "Lucas-Kanade optical flow", view, 30))
+                break;
 
             gray.CopyTo(prevGray);
             points = good.Select(i => nextPoints[i]).ToArray();

--- a/Samples/Samples/OpticalFlowSample.cs
+++ b/Samples/Samples/OpticalFlowSample.cs
@@ -63,7 +63,7 @@ class OpticalFlowSample : ConsoleTestBase
             }
             Cv2.Add(view, mask, view);
 
-            if (!DisplayHelper.ShowFrame(nameof(OpticalFlowSample), "Lucas-Kanade optical flow", view, 30))
+            if (!DisplayHelper.ShowFrame(nameof(OpticalFlowSample), ("Lucas-Kanade optical flow", view)))
                 break;
 
             gray.CopyTo(prevGray);

--- a/Samples/Samples/PerspectiveTransformSample.cs
+++ b/Samples/Samples/PerspectiveTransformSample.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -26,9 +27,9 @@ public class PerspectiveTransformSample : ConsoleTestBase
 
     private Mat OriginalImage;
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        if (DisplayHelper.IsHeadless)
+        if (display.IsHeadless)
         {
             PrintWarning("Skipping: this sample requires interactively clicking 4 corner points with the mouse and cannot be meaningfully verified headlessly.");
             return;

--- a/Samples/Samples/PerspectiveTransformSample.cs
+++ b/Samples/Samples/PerspectiveTransformSample.cs
@@ -28,6 +28,12 @@ public class PerspectiveTransformSample : ConsoleTestBase
 
     public override void RunTest()
     {
+        if (DisplayHelper.IsHeadless)
+        {
+            PrintWarning("Skipping: this sample requires interactively clicking 4 corner points with the mouse and cannot be meaningfully verified headlessly.");
+            return;
+        }
+
         OriginalImage = new Mat(ImagePath.SurfBoxinscene, ImreadModes.AnyColor);
         using var Window = new Window("result", OriginalImage);
 

--- a/Samples/Samples/PhotoMethods.cs
+++ b/Samples/Samples/PhotoMethods.cs
@@ -28,15 +28,9 @@ class PhotoMethods : ConsoleTestBase
         using var stylized = new Mat();
         Cv2.Stylization(src, stylized);
 
-        using (new Window("src", src))
-        using (new Window("edgePreservingFilter - NormconvFilter", normconv))
-        using (new Window("edgePreservingFilter - RecursFilter", recursFiltered))
-        using (new Window("detailEnhance", detailEnhance))
-        using (new Window("pencilSketch grayscale", pencil1))
-        using (new Window("pencilSketch color", pencil2))
-        using (new Window("stylized", stylized))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(
+            nameof(PhotoMethods),
+            new[] { "src", "edgePreservingFilter - NormconvFilter", "edgePreservingFilter - RecursFilter", "detailEnhance", "pencilSketch grayscale", "pencilSketch color", "stylized" },
+            new[] { src, normconv, recursFiltered, detailEnhance, pencil1, pencil2, stylized });
     }
 }

--- a/Samples/Samples/PhotoMethods.cs
+++ b/Samples/Samples/PhotoMethods.cs
@@ -30,7 +30,12 @@ class PhotoMethods : ConsoleTestBase
 
         DisplayHelper.Show(
             nameof(PhotoMethods),
-            new[] { "src", "edgePreservingFilter - NormconvFilter", "edgePreservingFilter - RecursFilter", "detailEnhance", "pencilSketch grayscale", "pencilSketch color", "stylized" },
-            new[] { src, normconv, recursFiltered, detailEnhance, pencil1, pencil2, stylized });
+            ("src", src),
+            ("edgePreservingFilter - NormconvFilter", normconv),
+            ("edgePreservingFilter - RecursFilter", recursFiltered),
+            ("detailEnhance", detailEnhance),
+            ("pencilSketch grayscale", pencil1),
+            ("pencilSketch color", pencil2),
+            ("stylized", stylized));
     }
 }

--- a/Samples/Samples/PhotoMethods.cs
+++ b/Samples/Samples/PhotoMethods.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class PhotoMethods : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = new Mat(ImagePath.Fruits, ImreadModes.Color);
 
@@ -28,8 +29,7 @@ class PhotoMethods : ConsoleTestBase
         using var stylized = new Mat();
         Cv2.Stylization(src, stylized);
 
-        DisplayHelper.Show(
-            nameof(PhotoMethods),
+        display.Show(
             ("src", src),
             ("edgePreservingFilter - NormconvFilter", normconv),
             ("edgePreservingFilter - RecursFilter", recursFiltered),

--- a/Samples/Samples/PixelAccess.cs
+++ b/Samples/Samples/PixelAccess.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -11,7 +12,7 @@ namespace SamplesCore;
 /// </summary>
 class PixelAccess : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         Console.WriteLine("Get/Set: {0}ms", MeasureTime(GetSet));
         Console.WriteLine("GenericIndexer: {0}ms", MeasureTime(GenericIndexer));

--- a/Samples/Samples/PixelAccess.cs
+++ b/Samples/Samples/PixelAccess.cs
@@ -16,7 +16,6 @@ class PixelAccess : ConsoleTestBase
         Console.WriteLine("Get/Set: {0}ms", MeasureTime(GetSet));
         Console.WriteLine("GenericIndexer: {0}ms", MeasureTime(GenericIndexer));
         Console.WriteLine("TypeSpecificMat: {0}ms", MeasureTime(TypeSpecificMat));
-        Console.Read();
     }
 
     /// <summary>

--- a/Samples/Samples/QRCodeDetectionSample.cs
+++ b/Samples/Samples/QRCodeDetectionSample.cs
@@ -29,8 +29,6 @@ class QRCodeDetectionSample : ConsoleTestBase
             ? "No QR code found."
             : $"Decoded text: {text}");
 
-        Window.ShowImages(
-            new[] { dst, straightQrCode },
-            new[] { "detected", "rectified" });
+        DisplayHelper.Show(nameof(QRCodeDetectionSample), new[] { "detected", "rectified" }, new[] { dst, straightQrCode });
     }
 }

--- a/Samples/Samples/QRCodeDetectionSample.cs
+++ b/Samples/Samples/QRCodeDetectionSample.cs
@@ -29,6 +29,6 @@ class QRCodeDetectionSample : ConsoleTestBase
             ? "No QR code found."
             : $"Decoded text: {text}");
 
-        DisplayHelper.Show(nameof(QRCodeDetectionSample), new[] { "detected", "rectified" }, new[] { dst, straightQrCode });
+        DisplayHelper.Show(nameof(QRCodeDetectionSample), ("detected", dst), ("rectified", straightQrCode));
     }
 }

--- a/Samples/Samples/QRCodeDetectionSample.cs
+++ b/Samples/Samples/QRCodeDetectionSample.cs
@@ -2,6 +2,7 @@ using System;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class QRCodeDetectionSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = new Mat(ImagePath.QrCode, ImreadModes.Color);
 
@@ -29,6 +30,6 @@ class QRCodeDetectionSample : ConsoleTestBase
             ? "No QR code found."
             : $"Decoded text: {text}");
 
-        DisplayHelper.Show(nameof(QRCodeDetectionSample), ("detected", dst), ("rectified", straightQrCode));
+        display.Show(("detected", dst), ("rectified", straightQrCode));
     }
 }

--- a/Samples/Samples/SVMSample.cs
+++ b/Samples/Samples/SVMSample.cs
@@ -48,7 +48,7 @@ internal class SVMSample : ConsoleTestBase
                 int y2 = (int)(300 - Function(x));
                 Cv2.Line(pointsPlot, x - 1, y1, x, y2, Scalar.LightBlue, 1);
             }
-            Window.ShowImages(pointsPlot);
+            DisplayHelper.Show(nameof(SVMSample), "pointsPlot", pointsPlot);
         }
 
         // Train
@@ -87,6 +87,6 @@ internal class SVMSample : ConsoleTestBase
                     Cv2.Rectangle(retPlot, plotRect, Scalar.GreenYellow);
             }
         }
-        Window.ShowImages(retPlot);
+        DisplayHelper.Show(nameof(SVMSample), "retPlot", retPlot);
     }
 }

--- a/Samples/Samples/SVMSample.cs
+++ b/Samples/Samples/SVMSample.cs
@@ -48,7 +48,7 @@ internal class SVMSample : ConsoleTestBase
                 int y2 = (int)(300 - Function(x));
                 Cv2.Line(pointsPlot, x - 1, y1, x, y2, Scalar.LightBlue, 1);
             }
-            DisplayHelper.Show(nameof(SVMSample), "pointsPlot", pointsPlot);
+            DisplayHelper.Show(nameof(SVMSample), ("pointsPlot", pointsPlot));
         }
 
         // Train
@@ -87,6 +87,6 @@ internal class SVMSample : ConsoleTestBase
                     Cv2.Rectangle(retPlot, plotRect, Scalar.GreenYellow);
             }
         }
-        DisplayHelper.Show(nameof(SVMSample), "retPlot", retPlot);
+        DisplayHelper.Show(nameof(SVMSample), ("retPlot", retPlot));
     }
 }

--- a/Samples/Samples/SVMSample.cs
+++ b/Samples/Samples/SVMSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using OpenCvSharp.ML;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -16,9 +17,9 @@ internal class SVMSample : ConsoleTestBase
         return x + 50 * Math.Sin(x / 15.0);
     }
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        // Training data          
+        // Training data
         var points = new Point2f[500];
         var responses = new int[points.Length];
         var rand = new Random();
@@ -48,7 +49,7 @@ internal class SVMSample : ConsoleTestBase
                 int y2 = (int)(300 - Function(x));
                 Cv2.Line(pointsPlot, x - 1, y1, x, y2, Scalar.LightBlue, 1);
             }
-            DisplayHelper.Show(nameof(SVMSample), ("pointsPlot", pointsPlot));
+            display.Show(("pointsPlot", pointsPlot));
         }
 
         // Train
@@ -87,6 +88,6 @@ internal class SVMSample : ConsoleTestBase
                     Cv2.Rectangle(retPlot, plotRect, Scalar.GreenYellow);
             }
         }
-        DisplayHelper.Show(nameof(SVMSample), ("retPlot", retPlot));
+        display.Show(("retPlot", retPlot));
     }
 }

--- a/Samples/Samples/SeamlessClone.cs
+++ b/Samples/Samples/SeamlessClone.cs
@@ -32,14 +32,8 @@ class SeamlessClone : ConsoleTestBase
                 src0, dst, mask, new Point(260, 270), blend3,
                 SeamlessCloneFlags.MixedClone);
 
-            using (new Window("src", src0))
-            using (new Window("dst", dst))
-            using (new Window("mask", mask))
-            using (new Window("blend NormalClone", blend1))
-            using (new Window("blend MonochromeTransfer", blend2))
-            using (new Window("blend MixedClone", blend3))
-            {
-                Cv2.WaitKey();
-            }
+            DisplayHelper.Show(nameof(SeamlessClone),
+                new[] { "src", "dst", "mask", "blend NormalClone", "blend MonochromeTransfer", "blend MixedClone" },
+                new[] { src0, dst, mask, blend1, blend2, blend3 });
         }
 }

--- a/Samples/Samples/SeamlessClone.cs
+++ b/Samples/Samples/SeamlessClone.cs
@@ -33,7 +33,7 @@ class SeamlessClone : ConsoleTestBase
                 SeamlessCloneFlags.MixedClone);
 
             DisplayHelper.Show(nameof(SeamlessClone),
-                new[] { "src", "dst", "mask", "blend NormalClone", "blend MonochromeTransfer", "blend MixedClone" },
-                new[] { src0, dst, mask, blend1, blend2, blend3 });
+                ("src", src0), ("dst", dst), ("mask", mask),
+                ("blend NormalClone", blend1), ("blend MonochromeTransfer", blend2), ("blend MixedClone", blend3));
         }
 }

--- a/Samples/Samples/SeamlessClone.cs
+++ b/Samples/Samples/SeamlessClone.cs
@@ -1,6 +1,7 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -9,7 +10,7 @@ namespace SamplesCore;
 /// </summary>
 class SeamlessClone : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
             Mat src = new Mat(ImagePath.Girl, ImreadModes.Color);
             Mat dst = new Mat(ImagePath.Fruits, ImreadModes.Color);
@@ -32,7 +33,7 @@ class SeamlessClone : ConsoleTestBase
                 src0, dst, mask, new Point(260, 270), blend3,
                 SeamlessCloneFlags.MixedClone);
 
-            DisplayHelper.Show(nameof(SeamlessClone),
+            display.Show(
                 ("src", src0), ("dst", dst), ("mask", mask),
                 ("blend NormalClone", blend1), ("blend MonochromeTransfer", blend2), ("blend MixedClone", blend3));
         }

--- a/Samples/Samples/SiftSurfSample.cs
+++ b/Samples/Samples/SiftSurfSample.cs
@@ -48,11 +48,9 @@ class SiftSurfSample : ConsoleTestBase
         using var flannView = new Mat();
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
-        using (new Window("SIFT matching (by BFMather)", bfView))
-        using (new Window("SIFT matching (by FlannBasedMatcher)", flannView))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(SiftSurfSample),
+            new[] { "SIFT matching (by BFMather)", "SIFT matching (by FlannBasedMatcher)" },
+            new[] { bfView, flannView });
     }
 
     private void MatchBySurf(Mat src1, Mat src2)
@@ -83,11 +81,9 @@ class SiftSurfSample : ConsoleTestBase
         using var flannView = new Mat();
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
-        using (new Window("SURF matching (by BFMather)", bfView))
-        using (new Window("SURF matching (by FlannBasedMatcher)", flannView))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(SiftSurfSample),
+            new[] { "SURF matching (by BFMather)", "SURF matching (by FlannBasedMatcher)" },
+            new[] { bfView, flannView });
     }
 
 }

--- a/Samples/Samples/SiftSurfSample.cs
+++ b/Samples/Samples/SiftSurfSample.cs
@@ -49,8 +49,7 @@ class SiftSurfSample : ConsoleTestBase
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
         DisplayHelper.Show(nameof(SiftSurfSample),
-            new[] { "SIFT matching (by BFMather)", "SIFT matching (by FlannBasedMatcher)" },
-            new[] { bfView, flannView });
+            ("SIFT matching (by BFMather)", bfView), ("SIFT matching (by FlannBasedMatcher)", flannView));
     }
 
     private void MatchBySurf(Mat src1, Mat src2)
@@ -82,8 +81,7 @@ class SiftSurfSample : ConsoleTestBase
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
         DisplayHelper.Show(nameof(SiftSurfSample),
-            new[] { "SURF matching (by BFMather)", "SURF matching (by FlannBasedMatcher)" },
-            new[] { bfView, flannView });
+            ("SURF matching (by BFMather)", bfView), ("SURF matching (by FlannBasedMatcher)", flannView));
     }
 
 }

--- a/Samples/Samples/SiftSurfSample.cs
+++ b/Samples/Samples/SiftSurfSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -11,16 +12,16 @@ namespace SamplesCore;
 /// </summary>
 class SiftSurfSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src1 = new Mat(ImagePath.Match1, ImreadModes.Color);
         using var src2 = new Mat(ImagePath.Match2, ImreadModes.Color);
 
-        MatchBySift(src1, src2);
-        MatchBySurf(src1, src2);
+        MatchBySift(src1, src2, display);
+        MatchBySurf(src1, src2, display);
     }
 
-    private void MatchBySift(Mat src1, Mat src2)
+    private void MatchBySift(Mat src1, Mat src2, DisplayHelper display)
     {
         using var gray1 = new Mat();
         using var gray2 = new Mat();
@@ -48,11 +49,11 @@ class SiftSurfSample : ConsoleTestBase
         using var flannView = new Mat();
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
-        DisplayHelper.Show(nameof(SiftSurfSample),
+        display.Show(
             ("SIFT matching (by BFMather)", bfView), ("SIFT matching (by FlannBasedMatcher)", flannView));
     }
 
-    private void MatchBySurf(Mat src1, Mat src2)
+    private void MatchBySurf(Mat src1, Mat src2, DisplayHelper display)
     {
         using var gray1 = new Mat();
         using var gray2 = new Mat();
@@ -80,7 +81,7 @@ class SiftSurfSample : ConsoleTestBase
         using var flannView = new Mat();
         Cv2.DrawMatches(gray1, keypoints1, gray2, keypoints2, flannMatches, flannView);
 
-        DisplayHelper.Show(nameof(SiftSurfSample),
+        display.Show(
             ("SURF matching (by BFMather)", bfView), ("SURF matching (by FlannBasedMatcher)", flannView));
     }
 

--- a/Samples/Samples/SimpleBlobDetectorSample.cs
+++ b/Samples/Samples/SimpleBlobDetectorSample.cs
@@ -1,12 +1,13 @@
 ﻿using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 internal class SimpleBlobDetectorSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var src = Cv2.ImRead(ImagePath.Shapes);
         using var detectedCircles = new Mat();
@@ -64,6 +65,6 @@ internal class SimpleBlobDetectorSample : ConsoleTestBase
         var ovalKeyPoints = ovalDetector.Detect(src);
         Cv2.DrawKeypoints(src, ovalKeyPoints, detectedOvals, Scalar.HotPink, DrawMatchesFlags.DrawRichKeypoints);
 
-        DisplayHelper.Show(nameof(SimpleBlobDetectorSample), ("Detected Circles", detectedCircles), ("Detected Ovals", detectedOvals));
+        display.Show(("Detected Circles", detectedCircles), ("Detected Ovals", detectedOvals));
     }
 }

--- a/Samples/Samples/SimpleBlobDetectorSample.cs
+++ b/Samples/Samples/SimpleBlobDetectorSample.cs
@@ -64,6 +64,6 @@ internal class SimpleBlobDetectorSample : ConsoleTestBase
         var ovalKeyPoints = ovalDetector.Detect(src);
         Cv2.DrawKeypoints(src, ovalKeyPoints, detectedOvals, Scalar.HotPink, DrawMatchesFlags.DrawRichKeypoints);
 
-        DisplayHelper.Show(nameof(SimpleBlobDetectorSample), new[] { "Detected Circles", "Detected Ovals" }, new[] { detectedCircles, detectedOvals });
+        DisplayHelper.Show(nameof(SimpleBlobDetectorSample), ("Detected Circles", detectedCircles), ("Detected Ovals", detectedOvals));
     }
 }

--- a/Samples/Samples/SimpleBlobDetectorSample.cs
+++ b/Samples/Samples/SimpleBlobDetectorSample.cs
@@ -64,9 +64,6 @@ internal class SimpleBlobDetectorSample : ConsoleTestBase
         var ovalKeyPoints = ovalDetector.Detect(src);
         Cv2.DrawKeypoints(src, ovalKeyPoints, detectedOvals, Scalar.HotPink, DrawMatchesFlags.DrawRichKeypoints);
 
-        using var w1 = new Window("Detected Circles", detectedCircles);
-        using var w2 = new Window("Detected Ovals", detectedOvals);
-
-        Cv2.WaitKey();
+        DisplayHelper.Show(nameof(SimpleBlobDetectorSample), new[] { "Detected Circles", "Detected Ovals" }, new[] { detectedCircles, detectedOvals });
     }
 }

--- a/Samples/Samples/SolveEquation.cs
+++ b/Samples/Samples/SolveEquation.cs
@@ -14,8 +14,6 @@ class SolveEquation : ConsoleTestBase
     {
         ByMat();
         ByNormalArray();
-
-        Console.Read();
     }
 
     /// <summary>

--- a/Samples/Samples/SolveEquation.cs
+++ b/Samples/Samples/SolveEquation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OpenCvSharp;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class SolveEquation : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         ByMat();
         ByNormalArray();

--- a/Samples/Samples/SquareDetectionSample.cs
+++ b/Samples/Samples/SquareDetectionSample.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -27,7 +28,7 @@ class SquareDetectionSample : ConsoleTestBase
         ImagePath.Square6,
     };
 
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         foreach (var path in ImagePaths)
         {
@@ -37,7 +38,7 @@ class SquareDetectionSample : ConsoleTestBase
             using var dst = src.Clone();
             Cv2.Polylines(dst, squares, true, Scalar.Red, 3, LineTypes.AntiAlias);
 
-            DisplayHelper.Show(nameof(SquareDetectionSample), (path, dst));
+            display.Show((path, dst));
         }
     }
 

--- a/Samples/Samples/SquareDetectionSample.cs
+++ b/Samples/Samples/SquareDetectionSample.cs
@@ -37,7 +37,7 @@ class SquareDetectionSample : ConsoleTestBase
             using var dst = src.Clone();
             Cv2.Polylines(dst, squares, true, Scalar.Red, 3, LineTypes.AntiAlias);
 
-            DisplayHelper.Show(nameof(SquareDetectionSample), path, dst);
+            DisplayHelper.Show(nameof(SquareDetectionSample), (path, dst));
         }
     }
 

--- a/Samples/Samples/SquareDetectionSample.cs
+++ b/Samples/Samples/SquareDetectionSample.cs
@@ -37,10 +37,7 @@ class SquareDetectionSample : ConsoleTestBase
             using var dst = src.Clone();
             Cv2.Polylines(dst, squares, true, Scalar.Red, 3, LineTypes.AntiAlias);
 
-            using (new Window(path, dst))
-            {
-                Cv2.WaitKey();
-            }
+            DisplayHelper.Show(nameof(SquareDetectionSample), path, dst);
         }
     }
 

--- a/Samples/Samples/StarDetectorSample.cs
+++ b/Samples/Samples/StarDetectorSample.cs
@@ -36,6 +36,6 @@ class StarDetectorSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(StarDetectorSample), "StarDetector features", dst);
+        DisplayHelper.Show(nameof(StarDetectorSample), ("StarDetector features", dst));
     }
 }

--- a/Samples/Samples/StarDetectorSample.cs
+++ b/Samples/Samples/StarDetectorSample.cs
@@ -36,9 +36,6 @@ class StarDetectorSample : ConsoleTestBase
             }
         }
 
-        using (new Window("StarDetector features", dst))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(StarDetectorSample), "StarDetector features", dst);
     }
 }

--- a/Samples/Samples/StarDetectorSample.cs
+++ b/Samples/Samples/StarDetectorSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp.XFeatures2D;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class StarDetectorSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         var dst = new Mat(ImagePath.Newspaper, ImreadModes.Color);
         var gray = new Mat(ImagePath.Newspaper, ImreadModes.Grayscale);
@@ -36,6 +37,6 @@ class StarDetectorSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(StarDetectorSample), ("StarDetector features", dst));
+        display.Show(("StarDetector features", dst));
     }
 }

--- a/Samples/Samples/StereoMatchingSample.cs
+++ b/Samples/Samples/StereoMatchingSample.cs
@@ -1,6 +1,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// <remarks>https://docs.opencv.org/4.x/dd/d53/tutorial_py_depthmap.html</remarks>
 class StereoMatchingSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         using var left = new Mat(ImagePath.TsukubaLeft, ImreadModes.Grayscale);
         using var right = new Mat(ImagePath.TsukubaRight, ImreadModes.Grayscale);
@@ -33,6 +34,6 @@ class StereoMatchingSample : ConsoleTestBase
         Cv2.Normalize(disparityBm, disparityBmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
         Cv2.Normalize(disparitySgbm, disparitySgbmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
 
-        DisplayHelper.Show(nameof(StereoMatchingSample), ("left", left), ("right", right), ("disparity (BM)", disparityBmView), ("disparity (SGBM)", disparitySgbmView));
+        display.Show(("left", left), ("right", right), ("disparity (BM)", disparityBmView), ("disparity (SGBM)", disparitySgbmView));
     }
 }

--- a/Samples/Samples/StereoMatchingSample.cs
+++ b/Samples/Samples/StereoMatchingSample.cs
@@ -33,6 +33,6 @@ class StereoMatchingSample : ConsoleTestBase
         Cv2.Normalize(disparityBm, disparityBmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
         Cv2.Normalize(disparitySgbm, disparitySgbmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
 
-        DisplayHelper.Show(nameof(StereoMatchingSample), new[] { "left", "right", "disparity (BM)", "disparity (SGBM)" }, new[] { left, right, disparityBmView, disparitySgbmView });
+        DisplayHelper.Show(nameof(StereoMatchingSample), ("left", left), ("right", right), ("disparity (BM)", disparityBmView), ("disparity (SGBM)", disparitySgbmView));
     }
 }

--- a/Samples/Samples/StereoMatchingSample.cs
+++ b/Samples/Samples/StereoMatchingSample.cs
@@ -33,8 +33,6 @@ class StereoMatchingSample : ConsoleTestBase
         Cv2.Normalize(disparityBm, disparityBmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
         Cv2.Normalize(disparitySgbm, disparitySgbmView, 0, 255, NormTypes.MinMax, MatType.CV_8U);
 
-        Window.ShowImages(
-            new[] { left, right, disparityBmView, disparitySgbmView },
-            new[] { "left", "right", "disparity (BM)", "disparity (SGBM)" });
+        DisplayHelper.Show(nameof(StereoMatchingSample), new[] { "left", "right", "disparity (BM)", "disparity (SGBM)" }, new[] { left, right, disparityBmView, disparitySgbmView });
     }
 }

--- a/Samples/Samples/Stitching.cs
+++ b/Samples/Samples/Stitching.cs
@@ -3,14 +3,15 @@ using System.Collections.Generic;
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
 class Stitching : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        Mat[] images = SelectStitchingImages(200, 200, 10);
+        Mat[] images = SelectStitchingImages(200, 200, 10, display);
 
         using var stitcher = Stitcher.Create(Stitcher.Mode.Scans);
         using var pano = new Mat();
@@ -20,7 +21,7 @@ class Stitching : ConsoleTestBase
         var status = stitcher.Stitch(images, pano);
         Console.WriteLine(" finish (status:{0})", status);
 
-        DisplayHelper.Show(nameof(Stitching), ("pano", pano));
+        display.Show(("pano", pano));
 
         foreach (var image in images)
         {
@@ -28,7 +29,7 @@ class Stitching : ConsoleTestBase
         }
     }
 
-    private static Mat[] SelectStitchingImages(int width, int height, int count)
+    private static Mat[] SelectStitchingImages(int width, int height, int count, DisplayHelper display)
     {
         using var source = new Mat(ImagePath.Asahiyama, ImreadModes.Color);
         using var result = source.Clone();
@@ -51,7 +52,7 @@ class Stitching : ConsoleTestBase
             mats.Add(m.Clone());
         }
 
-        DisplayHelper.Show(nameof(Stitching), ("stitching", result));
+        display.Show(("stitching", result));
 
         return mats.ToArray();
     }

--- a/Samples/Samples/Stitching.cs
+++ b/Samples/Samples/Stitching.cs
@@ -20,7 +20,7 @@ class Stitching : ConsoleTestBase
         var status = stitcher.Stitch(images, pano);
         Console.WriteLine(" finish (status:{0})", status);
 
-        DisplayHelper.Show(nameof(Stitching), "pano", pano);
+        DisplayHelper.Show(nameof(Stitching), ("pano", pano));
 
         foreach (var image in images)
         {
@@ -51,7 +51,7 @@ class Stitching : ConsoleTestBase
             mats.Add(m.Clone());
         }
 
-        DisplayHelper.Show(nameof(Stitching), "stitching", result);
+        DisplayHelper.Show(nameof(Stitching), ("stitching", result));
 
         return mats.ToArray();
     }

--- a/Samples/Samples/Stitching.cs
+++ b/Samples/Samples/Stitching.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenCvSharp;
+using SampleBase;
 using SampleBase.Console;
 
 namespace SamplesCore;
@@ -19,7 +20,7 @@ class Stitching : ConsoleTestBase
         var status = stitcher.Stitch(images, pano);
         Console.WriteLine(" finish (status:{0})", status);
 
-        Window.ShowImages(pano);
+        DisplayHelper.Show(nameof(Stitching), "pano", pano);
 
         foreach (var image in images)
         {
@@ -29,7 +30,7 @@ class Stitching : ConsoleTestBase
 
     private static Mat[] SelectStitchingImages(int width, int height, int count)
     {
-        using var source = new Mat(@"Data\Image\lenna.png", ImreadModes.Color);
+        using var source = new Mat(ImagePath.Asahiyama, ImreadModes.Color);
         using var result = source.Clone();
 
         var rand = new Random();
@@ -50,10 +51,7 @@ class Stitching : ConsoleTestBase
             mats.Add(m.Clone());
         }
 
-        using (new Window("stitching", result))
-        {
-            Cv2.WaitKey();
-        }
+        DisplayHelper.Show(nameof(Stitching), "stitching", result);
 
         return mats.ToArray();
     }

--- a/Samples/Samples/Subdiv2DSample.cs
+++ b/Samples/Samples/Subdiv2DSample.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using OpenCvSharp;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class Subdiv2DSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         const int Size = 600;
 
@@ -55,6 +56,6 @@ class Subdiv2DSample : ConsoleTestBase
             Cv2.Line(delaunay, p1, p2, new Scalar(64, 255, 128), 1);
         }
 
-        DisplayHelper.Show(nameof(Subdiv2DSample), ("voronoi", vonoroi), ("delaunay", delaunay));
+        display.Show(("voronoi", vonoroi), ("delaunay", delaunay));
     }
 }

--- a/Samples/Samples/Subdiv2DSample.cs
+++ b/Samples/Samples/Subdiv2DSample.cs
@@ -55,6 +55,6 @@ class Subdiv2DSample : ConsoleTestBase
             Cv2.Line(delaunay, p1, p2, new Scalar(64, 255, 128), 1);
         }
 
-        DisplayHelper.Show(nameof(Subdiv2DSample), new[] { "voronoi", "delaunay" }, new[] { vonoroi, delaunay });
+        DisplayHelper.Show(nameof(Subdiv2DSample), ("voronoi", vonoroi), ("delaunay", delaunay));
     }
 }

--- a/Samples/Samples/Subdiv2DSample.cs
+++ b/Samples/Samples/Subdiv2DSample.cs
@@ -55,9 +55,6 @@ class Subdiv2DSample : ConsoleTestBase
             Cv2.Line(delaunay, p1, p2, new Scalar(64, 255, 128), 1);
         }
 
-        Cv2.ImShow("voronoi", vonoroi);
-        Cv2.ImShow("delaunay", delaunay);
-        Cv2.WaitKey();
-        Cv2.DestroyAllWindows();
+        DisplayHelper.Show(nameof(Subdiv2DSample), new[] { "voronoi", "delaunay" }, new[] { vonoroi, delaunay });
     }
 }

--- a/Samples/Samples/VideoCaptureSample.cs
+++ b/Samples/Samples/VideoCaptureSample.cs
@@ -29,7 +29,7 @@ class VideoCaptureSample : ConsoleTestBase
                 if(image.Empty())
                     break;
 
-                if (!DisplayHelper.ShowFrame(nameof(VideoCaptureSample), "capture", image, sleepTime))
+                if (!DisplayHelper.ShowFrame(nameof(VideoCaptureSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
                     break;
             }
         }

--- a/Samples/Samples/VideoCaptureSample.cs
+++ b/Samples/Samples/VideoCaptureSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class VideoCaptureSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
             // Opens MP4 file (ffmpeg is probably needed)
             using var capture = new VideoCapture(MoviePath.Bach);
@@ -29,7 +30,7 @@ class VideoCaptureSample : ConsoleTestBase
                 if(image.Empty())
                     break;
 
-                if (!DisplayHelper.ShowFrame(nameof(VideoCaptureSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
+                if (!display.ShowFrame(waitMs: sleepTime, maxHeadlessFrames: 5, ("capture", image)))
                     break;
             }
         }

--- a/Samples/Samples/VideoCaptureSample.cs
+++ b/Samples/Samples/VideoCaptureSample.cs
@@ -19,7 +19,6 @@ class VideoCaptureSample : ConsoleTestBase
 
             int sleepTime = (int)Math.Round(1000 / capture.Fps);
 
-            using var window = new Window("capture");
             // Frame image buffer
             var image = new Mat();
 
@@ -30,8 +29,8 @@ class VideoCaptureSample : ConsoleTestBase
                 if(image.Empty())
                     break;
 
-                window.ShowImage(image);
-                Cv2.WaitKey(sleepTime);
+                if (!DisplayHelper.ShowFrame(nameof(VideoCaptureSample), "capture", image, sleepTime))
+                    break;
             }
         }
 }

--- a/Samples/Samples/VideoWriterSample.cs
+++ b/Samples/Samples/VideoWriterSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -10,7 +11,7 @@ namespace SamplesCore;
 /// </summary>
 class VideoWriterSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
         const string OutVideoFile = "out.avi";
 
@@ -65,7 +66,7 @@ class VideoWriterSample : ConsoleTestBase
                 if (frame.Empty())
                     break;
 
-                if (!DisplayHelper.ShowFrame(nameof(VideoWriterSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("result", frame)))
+                if (!display.ShowFrame(waitMs: sleepTime, maxHeadlessFrames: 5, ("result", frame)))
                     break;
             }
         }

--- a/Samples/Samples/VideoWriterSample.cs
+++ b/Samples/Samples/VideoWriterSample.cs
@@ -65,7 +65,7 @@ class VideoWriterSample : ConsoleTestBase
                 if (frame.Empty())
                     break;
 
-                if (!DisplayHelper.ShowFrame(nameof(VideoWriterSample), "result", frame, sleepTime))
+                if (!DisplayHelper.ShowFrame(nameof(VideoWriterSample), waitMs: sleepTime, maxHeadlessFrames: 5, ("result", frame)))
                     break;
             }
         }

--- a/Samples/Samples/VideoWriterSample.cs
+++ b/Samples/Samples/VideoWriterSample.cs
@@ -17,9 +17,11 @@ class VideoWriterSample : ConsoleTestBase
         // Opens MP4 file (ffmpeg is probably needed)
         using var capture = new VideoCapture(MoviePath.Bach);
 
-        // Read movie frames and write them to VideoWriter 
+        // Read movie frames and write them to VideoWriter
         var dsize = new Size(640, 480);
-        using (var writer = new VideoWriter(OutVideoFile, -1, capture.Fps, dsize))
+        int fourcc = VideoWriter.FourCC('M', 'J', 'P', 'G');
+        // isColor: false because the frames written below (grayscale -> Canny) are single-channel.
+        using (var writer = new VideoWriter(OutVideoFile, fourcc, capture.Fps, dsize, isColor: false))
         {
             Console.WriteLine("Converting each movie frames...");
             using var frame = new Mat();
@@ -30,8 +32,13 @@ class VideoWriterSample : ConsoleTestBase
                 if (frame.Empty())
                     break;
 
-                Console.CursorLeft = 0;
-                Console.Write("{0} / {1}", capture.PosFrames, capture.FrameCount);
+                // Console.CursorLeft throws when stdout is redirected (e.g. piped/CI), so only
+                // do the in-place progress update when attached to a real console.
+                if (!Console.IsOutputRedirected)
+                {
+                    Console.CursorLeft = 0;
+                    Console.Write("{0} / {1}", capture.PosFrames, capture.FrameCount);
+                }
 
                 // grayscale -> canny -> resize
                 using var gray = new Mat();
@@ -48,7 +55,6 @@ class VideoWriterSample : ConsoleTestBase
 
         // Watch result movie
         using (var capture2 = new VideoCapture(OutVideoFile))
-        using (var window = new Window("result"))
         {
             int sleepTime = (int)(1000 / capture.Fps);
 
@@ -59,8 +65,8 @@ class VideoWriterSample : ConsoleTestBase
                 if (frame.Empty())
                     break;
 
-                window.ShowImage(frame);
-                Cv2.WaitKey(sleepTime);
+                if (!DisplayHelper.ShowFrame(nameof(VideoWriterSample), "result", frame, sleepTime))
+                    break;
             }
         }
     }

--- a/Samples/Samples/WatershedSample.cs
+++ b/Samples/Samples/WatershedSample.cs
@@ -2,6 +2,7 @@
 using OpenCvSharp;
 using SampleBase;
 using SampleBase.Console;
+using SampleBase.Interfaces;
 
 namespace SamplesCore;
 
@@ -11,9 +12,9 @@ namespace SamplesCore;
 /// <remarks>http://opencv.jp/sample/segmentation_and_connection.html#watershed</remarks>
 public class WatershedSample : ConsoleTestBase
 {
-    public override void RunTest()
+    public override void RunTest(DisplayHelper display)
     {
-        if (DisplayHelper.IsHeadless)
+        if (display.IsHeadless)
         {
             PrintWarning("Skipping: this sample requires interactively marking seed points with the mouse and cannot be meaningfully verified headlessly.");
             return;
@@ -60,6 +61,6 @@ public class WatershedSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(WatershedSample), ("watershed transform", dstImg));
+        display.Show(("watershed transform", dstImg));
     }
 }

--- a/Samples/Samples/WatershedSample.cs
+++ b/Samples/Samples/WatershedSample.cs
@@ -60,6 +60,6 @@ public class WatershedSample : ConsoleTestBase
             }
         }
 
-        DisplayHelper.Show(nameof(WatershedSample), "watershed transform", dstImg);
+        DisplayHelper.Show(nameof(WatershedSample), ("watershed transform", dstImg));
     }
 }

--- a/Samples/Samples/WatershedSample.cs
+++ b/Samples/Samples/WatershedSample.cs
@@ -13,6 +13,12 @@ public class WatershedSample : ConsoleTestBase
 {
     public override void RunTest()
     {
+        if (DisplayHelper.IsHeadless)
+        {
+            PrintWarning("Skipping: this sample requires interactively marking seed points with the mouse and cannot be meaningfully verified headlessly.");
+            return;
+        }
+
         using var srcImg = Cv2.ImRead(ImagePath.Asahiyama, ImreadModes.AnyDepth | ImreadModes.AnyColor);
         using var markers = new Mat(srcImg.Size(), MatType.CV_32SC1, Scalar.All(0));
 
@@ -54,9 +60,6 @@ public class WatershedSample : ConsoleTestBase
             }
         }
 
-        using (new Window("watershed transform", dstImg))
-        {
-            Window.WaitKey();
-        }
+        DisplayHelper.Show(nameof(WatershedSample), "watershed transform", dstImg);
     }
 }


### PR DESCRIPTION
## Summary
- 44 of 47 samples showed results through three inconsistent idioms (`Window.ShowImages`, raw `ImShow`+`WaitKey`+`DestroyAllWindows`, or `new Window(...)` instances), all of which need a real display and hang or throw with no GUI backend. Verifying a sample without a display used to mean temporarily hand-editing in `Cv2.ImWrite` calls.
- Added `SampleBase.Console.DisplayHelper`, a single `Show`/`ShowFrame` API that replaces all three idioms. Set `OPENCV_SAMPLES_HEADLESS=1` (or run under CI, auto-detected) to write PNGs to `./headless-output/<Sample>/` instead of opening windows; interactive behavior is otherwise unchanged.
- Video-loop samples cap headless output at a few frames per run. Samples that are inherently interactive (mouse-driven seed marking, corner picking, paint-then-inpaint) skip themselves with a message when headless, since there's no way to automate them meaningfully.
- `ConsoleTestManager` now closes windows after every run so the REPL doesn't accumulate windows across samples.
- This is PR2 of the stack started in #48 (auto-registration → headless execution → folder/naming cleanup → interface simplification).

Also fixed three unrelated bugs surfaced by finally being able to run every sample end-to-end in one pass:
- `Stitching.cs` referenced the deleted `lenna.png` by a hardcoded path (missed by #47's cleanup) instead of an `ImagePath` constant.
- `VideoWriterSample` used `fourcc=-1`, which opens a blocking native codec-selection dialog on Windows, and wrote grayscale frames to a color-configured writer (every frame silently dropped); it also called `Console.CursorLeft`, which throws when stdout is redirected.
- `FlannSample`/`PixelAccess`/`SolveEquation` called `Console.Read()` to pause for a keypress, which under piped/scripted input eats one character and desyncs the next menu selection.

## Test plan
- [x] `dotnet build Samples/Samples.csproj` succeeds with 0 errors
- [x] `OPENCV_SAMPLES_HEADLESS=1`, ran all 47 samples end-to-end via piped input: each runs exactly once, reaches a clean exit, no hangs, no window popups. 46/47 complete without error (the one exception is a pre-existing, unrelated `MDS.cs` math bug caught gracefully by the REPL's error handling — left out of scope for this PR).
- [x] Verified `headless-output/` is populated with PNGs for every sample that has visual output, including the loop-based and multi-image ones.
- [x] Re-ran without the env var to confirm interactive display behavior is unchanged.