### PR TITLE
Add Samples.WebApi: OpenCvSharp over ASP.NET Core minimal API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin/
+**/obj/
+**/.vs/
+.git/
+.claude/
+*.user

--- a/OpenCvSharpSamples.sln
+++ b/OpenCvSharpSamples.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VideoCaptureWPF", "VideoCap
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvaloniaViewer", "AvaloniaViewer\AvaloniaViewer.csproj", "{C6E27FC4-FDAB-447E-903B-C484533B6713}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.WebApi", "Samples.WebApi\Samples.WebApi.csproj", "{702D6150-2C2E-4482-899B-B52E24C5BAA2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,26 @@ Global
 		{C6E27FC4-FDAB-447E-903B-C484533B6713}.Release|x64.Build.0 = Release|Any CPU
 		{C6E27FC4-FDAB-447E-903B-C484533B6713}.Release|x86.ActiveCfg = Release|Any CPU
 		{C6E27FC4-FDAB-447E-903B-C484533B6713}.Release|x86.Build.0 = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|ARM.Build.0 = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|x64.Build.0 = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Debug|x86.Build.0 = Debug|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|ARM.ActiveCfg = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|ARM.Build.0 = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|ARM64.Build.0 = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x64.ActiveCfg = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x64.Build.0 = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x86.ActiveCfg = Release|Any CPU
+		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ If you need samples for the older **OpenCvSharp4** (OpenCV 4.x) API, check out t
 - `VideoCaptureForm` WinForms sample
 - `VideoCaptureWPF` WPF sample
 - `AvaloniaViewer` Avalonia sample: live Canny edge detection preview driven by sliders
+- `Samples.WebApi` ASP.NET Core Web API sample: image cartoonify endpoint and a streamed per-frame video analysis endpoint

--- a/Samples.WebApi/Dockerfile
+++ b/Samples.WebApi/Dockerfile
@@ -1,0 +1,38 @@
+# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+#
+# Build context is the repository root, since the Data assets under Samples/Data/ are
+# pulled in via a Content link in Samples.WebApi.csproj. Build and run from the repo root:
+#   docker build -f Samples.WebApi/Dockerfile -t samples-webapi .
+#   docker run --rm -p 8080:8080 samples-webapi
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+# The full (non-slim) OpenCvSharp5.official.runtime.linux-x64 package links highgui against
+# GTK3, so the native library fails to load without it even though this app never calls
+# highgui. FFmpeg (needed by VideoCapture) is statically linked into that package already.
+# libdrm2/libatomic1 are further transitive dependencies not pulled in automatically
+# (confirmed via `ldd libOpenCvSharpExtern.so`, since --no-install-recommends omits them).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgtk-3-0 libdrm2 libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+USER app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["Samples.WebApi/Samples.WebApi.csproj", "Samples.WebApi/"]
+RUN dotnet restore "Samples.WebApi/Samples.WebApi.csproj"
+COPY . .
+WORKDIR "/src/Samples.WebApi"
+RUN dotnet build "Samples.WebApi.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "Samples.WebApi.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Samples.WebApi.dll"]

--- a/Samples.WebApi/Program.cs
+++ b/Samples.WebApi/Program.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using OpenCvSharp;
+
+// Resolved against the output directory, not the process's current directory, since
+// `dotnet run` starts with the project folder as the working directory.
+var defaultImagePath = Path.Combine(AppContext.BaseDirectory, "Data", "Image", "Mandrill.bmp");
+var defaultVideoPath = Path.Combine(AppContext.BaseDirectory, "Data", "Movie", "bach.mp4");
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+app.MapPost("/api/cartoonify", async (HttpRequest request) =>
+{
+    var image = await GetOptionalFileAsync(request, "image");
+    using var src = await LoadSourceImageAsync(image, defaultImagePath);
+    if (src.Empty())
+    {
+        return Results.BadRequest("Could not decode the uploaded file as an image.");
+    }
+
+    using var gray = new Mat();
+    Cv2.CvtColor(src, gray, ColorConversionCodes.BGR2GRAY);
+    Cv2.MedianBlur(gray, gray, 9);
+
+    // Edge mask: dark lines (0) on a mostly white (255) background. A larger block size
+    // and C cut down on speckling from fine texture (fur, skin) that isn't a real outline.
+    using var edges = new Mat();
+    Cv2.AdaptiveThreshold(gray, edges, 255, AdaptiveThresholdTypes.MeanC, ThresholdTypes.Binary, 15, 20);
+
+    // Flatten flat color regions while keeping edges; two passes make the flattening
+    // more pronounced than a single call.
+    using var smooth1 = new Mat();
+    using var smooth2 = new Mat();
+    Cv2.BilateralFilter(src, smooth1, 9, 200, 200);
+    Cv2.BilateralFilter(smooth1, smooth2, 9, 200, 200);
+
+    using var cartoon = new Mat();
+    Cv2.BitwiseAnd(smooth2, smooth2, cartoon, edges);
+
+    Cv2.ImEncode(".png", cartoon, out var png);
+    return Results.File(png, "image/png");
+});
+
+app.MapPost("/api/frame-analysis", async (HttpRequest request) =>
+{
+    var video = await GetOptionalFileAsync(request, "video");
+    return AnalyzeFramesAsync(video, defaultVideoPath);
+});
+
+app.Run();
+
+static async Task<IFormFile?> GetOptionalFileAsync(HttpRequest request, string fieldName)
+{
+    if (!request.HasFormContentType)
+    {
+        return null;
+    }
+
+    var form = await request.ReadFormAsync();
+    return form.Files[fieldName];
+}
+
+static async Task<Mat> LoadSourceImageAsync(IFormFile? image, string defaultImagePath)
+{
+    if (image is { Length: > 0 })
+    {
+        using var ms = new MemoryStream();
+        await image.CopyToAsync(ms);
+        return Cv2.ImDecode(ms.ToArray(), ImreadModes.Color);
+    }
+
+    return Cv2.ImRead(defaultImagePath, ImreadModes.Color);
+}
+
+static async IAsyncEnumerable<FrameAnalysis> AnalyzeFramesAsync(IFormFile? video, string defaultVideoPath)
+{
+    string? tempPath = null;
+    try
+    {
+        var videoPath = defaultVideoPath;
+        if (video is { Length: > 0 })
+        {
+            tempPath = Path.GetTempFileName();
+            await using var fileStream = File.Create(tempPath);
+            await video.CopyToAsync(fileStream);
+            videoPath = tempPath;
+        }
+
+        using var capture = new VideoCapture(videoPath);
+        if (!capture.IsOpened())
+        {
+            yield break;
+        }
+
+        using var frame = new Mat();
+        using var gray = new Mat();
+        using var edges = new Mat();
+
+        var frameIndex = 0;
+        while (true)
+        {
+            capture.Read(frame);
+            if (frame.Empty())
+            {
+                break;
+            }
+
+            Cv2.CvtColor(frame, gray, ColorConversionCodes.BGR2GRAY);
+            Cv2.Canny(gray, edges, 80, 160);
+
+            var brightness = Cv2.Mean(gray).Val0;
+            var edgeRatio = (double)Cv2.CountNonZero(edges) / (edges.Rows * edges.Cols);
+
+            yield return new FrameAnalysis(frameIndex, frame.Width, frame.Height, brightness, edgeRatio);
+            frameIndex++;
+        }
+    }
+    finally
+    {
+        if (tempPath is not null)
+        {
+            File.Delete(tempPath);
+        }
+    }
+}
+
+sealed record FrameAnalysis(int FrameIndex, int Width, int Height, double Brightness, double EdgeRatio);

--- a/Samples.WebApi/Samples.WebApi.csproj
+++ b/Samples.WebApi/Samples.WebApi.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260702" />
     <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260702" />
+    <PackageReference Include="OpenCvSharp5.official.runtime.linux-x64" Version="5.0.0.20260702" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples.WebApi/Samples.WebApi.csproj
+++ b/Samples.WebApi/Samples.WebApi.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Samples.WebApi</RootNamespace>
+    <AssemblyName>Samples.WebApi</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260702" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260702" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\Samples\Data\Image\Mandrill.bmp" Link="Data\Image\Mandrill.bmp">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\Samples\Data\Movie\bach.mp4" Link="Data\Movie\bach.mp4">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/Samples.WebApi/wwwroot/index.html
+++ b/Samples.WebApi/wwwroot/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Samples.WebApi</title>
+<style>
+  body { font-family: sans-serif; margin: 2rem; max-width: 900px; }
+  section { margin-bottom: 3rem; }
+  img { max-width: 400px; border: 1px solid #ccc; margin-right: 1rem; }
+  pre { background: #f4f4f4; padding: 0.75rem; height: 240px; overflow-y: auto; }
+</style>
+</head>
+<body>
+
+<h1>Samples.WebApi</h1>
+<p>Small OpenCvSharp samples exposed over ASP.NET Core Web API. Leave the file input empty to process the bundled sample image/video.</p>
+
+<section>
+  <h2>POST /api/cartoonify</h2>
+  <input type="file" id="imageInput" accept="image/*">
+  <button id="cartoonifyButton">Cartoonify</button>
+  <div>
+    <img id="cartoonResult" alt="cartoonify result">
+  </div>
+</section>
+
+<section>
+  <h2>POST /api/frame-analysis (streamed)</h2>
+  <input type="file" id="videoInput" accept="video/*">
+  <button id="analyzeButton">Analyze frames</button>
+  <pre id="analyzeLog"></pre>
+</section>
+
+<script>
+async function postForm(url, fileInput, fieldName) {
+  const form = new FormData();
+  if (fileInput.files.length > 0) {
+    form.append(fieldName, fileInput.files[0]);
+  }
+  return fetch(url, { method: 'POST', body: form });
+}
+
+document.getElementById('cartoonifyButton').addEventListener('click', async () => {
+  const response = await postForm('/api/cartoonify', document.getElementById('imageInput'), 'image');
+  if (!response.ok) {
+    alert(`Request failed: ${response.status} ${await response.text()}`);
+    return;
+  }
+  const blob = await response.blob();
+  document.getElementById('cartoonResult').src = URL.createObjectURL(blob);
+});
+
+document.getElementById('analyzeButton').addEventListener('click', async () => {
+  const log = document.getElementById('analyzeLog');
+  log.textContent = '';
+  const start = performance.now();
+
+  const response = await postForm('/api/frame-analysis', document.getElementById('videoInput'), 'video');
+  if (!response.ok || !response.body) {
+    log.textContent = `Request failed: ${response.status} ${await response.text()}`;
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+    log.textContent += `[+${elapsed}s chunk, ${value.length} bytes]\n${decoder.decode(value, { stream: true })}\n\n`;
+    log.scrollTop = log.scrollHeight;
+  }
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `Samples.WebApi`, a minimal-API ASP.NET Core project showing OpenCvSharp used from a Web API instead of a desktop/console app.
- `POST /api/cartoonify`: grayscale + adaptive-threshold edge mask, two bilateral-filter passes for color flattening, then `Cv2.BitwiseAnd` to stamp the edges back on. Returns a PNG.
- `POST /api/frame-analysis`: reads an uploaded video frame by frame and streams brightness/edge-ratio stats back as they're computed, using `IAsyncEnumerable<T>` so the response is flushed per item instead of buffered.
- Both endpoints fall back to a bundled sample (`Mandrill.bmp` / `bach.mp4`, referenced from `Samples/Data` via a `Content` link so the binaries aren't duplicated) when no file is uploaded.
- A small `wwwroot/index.html` page is included for manual testing in a browser, since Swagger/OpenAPI UI wouldn't show the streaming behavior or an image preview.

## Test plan
- [x] `dotnet build OpenCvSharpSamples.sln` succeeds
- [x] `POST /api/cartoonify` with no body returns a cartoonified PNG of the default image
- [x] `POST /api/cartoonify` with an uploaded image returns a cartoonified PNG of that image
- [x] `POST /api/frame-analysis` with no body streams per-frame JSON for the default video (verified `time_starttransfer` << `time_total`, and multiple distinct chunks arriving over time in the browser)
- [x] `POST /api/frame-analysis` with an uploaded video works the same way
- [x] Manually exercised both endpoints from `wwwroot/index.html` in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ASP.NET Core Web API sample with `/api/cartoonify` for image processing.
  * Added streamed `/api/frame-analysis` to analyze video frames with brightness and edge metrics.
  * Added a browser-based UI to upload images/videos and view results.
  * Included default sample image/video media for quick testing.
* **Documentation**
  * Updated the README with the new Web API sample details.
* **Chores**
  * Added Docker support for building and running the Web API sample.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->