### PR TITLE
Add Renovate config and a build/test CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "8.0.x"
@@ -25,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "8.0.x"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-windows:
+    # Samples.Windows / VideoCaptureForm / VideoCaptureWPF target net8.0-windows,
+    # so the full solution can only be built on a Windows runner.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "8.0.x"
+      - run: dotnet restore OpenCvSharpSamples.sln
+      - run: dotnet build OpenCvSharpSamples.sln --no-restore --configuration Release
+
+  build-and-test-linux:
+    # Samples.WebApi additionally targets linux-x64 via OpenCvSharp5.official.runtime.linux-x64,
+    # so verify it builds and its tests pass on Linux too.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "8.0.x"
+      - run: dotnet restore Samples.WebApi/Samples.WebApi.csproj
+      - run: dotnet build Samples.WebApi/Samples.WebApi.csproj --no-restore --configuration Release
+      - run: dotnet test tests/Samples.WebApi.Tests/Samples.WebApi.Tests.csproj --configuration Release

--- a/OpenCvSharpSamples.sln
+++ b/OpenCvSharpSamples.sln
@@ -15,6 +15,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvaloniaViewer", "AvaloniaV
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.WebApi", "Samples.WebApi\Samples.WebApi.csproj", "{702D6150-2C2E-4482-899B-B52E24C5BAA2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.WebApi.Tests", "tests\Samples.WebApi.Tests\Samples.WebApi.Tests.csproj", "{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -149,9 +153,32 @@ Global
 		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x64.Build.0 = Release|Any CPU
 		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x86.ActiveCfg = Release|Any CPU
 		{702D6150-2C2E-4482-899B-B52E24C5BAA2}.Release|x86.Build.0 = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|ARM.Build.0 = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|x64.Build.0 = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Debug|x86.Build.0 = Debug|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|ARM.ActiveCfg = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|ARM.Build.0 = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|ARM64.Build.0 = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|x64.ActiveCfg = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|x64.Build.0 = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|x86.ActiveCfg = Release|Any CPU
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{03B8E641-80BB-4BAA-B107-0619C1EE7C6C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1AC6F14A-E5DF-40A4-AACE-6E3BC5E00CFC}

--- a/Samples.WebApi/Program.cs
+++ b/Samples.WebApi/Program.cs
@@ -133,3 +133,7 @@ static async IAsyncEnumerable<FrameAnalysis> AnalyzeFramesAsync(IFormFile? video
 }
 
 sealed record FrameAnalysis(int FrameIndex, int Width, int Height, double Brightness, double EdgeRatio);
+
+// Exposes the top-level statements' generated Program class to Samples.WebApi.Tests,
+// which needs it as the generic argument for WebApplicationFactory<Program>.
+public partial class Program;

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^OpenCvSharp5/"],
+      "groupName": "OpenCvSharp5",
+      "groupSlug": "opencvsharp5"
+    }
+  ]
+}

--- a/tests/Samples.WebApi.Tests/CartoonifyEndpointTests.cs
+++ b/tests/Samples.WebApi.Tests/CartoonifyEndpointTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Samples.WebApi.Tests;
+
+public class CartoonifyEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public CartoonifyEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Cartoonify_WithoutUpload_ReturnsPngOfDefaultImage()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsync("/api/cartoonify", content: null, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact]
+    public async Task FrameAnalysis_WithoutUpload_ReturnsAtLeastOneFrame()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsync("/api/frame-analysis", content: null, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.GetArrayLength() > 0);
+    }
+}

--- a/tests/Samples.WebApi.Tests/Samples.WebApi.Tests.csproj
+++ b/tests/Samples.WebApi.Tests/Samples.WebApi.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Samples.WebApi\Samples.WebApi.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Add `renovate.json` to catch up promptly when OpenCvSharp5 NuGet packages are updated, grouping all `OpenCvSharp5.*` packages into a single PR since they need to stay on matching versions
- Add `.github/workflows/build.yml` (no CI existed before): builds the full solution on Windows (required for the WinForms/WPF-only samples), and separately builds + tests `Samples.WebApi` on Linux since it also targets `linux-x64`
- Add a minimal `Samples.WebApi.Tests` project under `tests/` covering the `/api/cartoonify` and `/api/frame-analysis` endpoints, migrated to xUnit v3 (xUnit v2 packages are deprecated)

## Test plan
- [x] `dotnet build OpenCvSharpSamples.sln` succeeds locally
- [x] `dotnet test tests/Samples.WebApi.Tests/Samples.WebApi.Tests.csproj` passes (2/2)
- [ ] CI workflow runs green on this PR
- [ ] Enable the Renovate GitHub App on this repository (manual step, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated CI build validation for Windows and Linux on push and pull requests.
  - Introduced integration tests covering the cartoonify and frame-analysis API endpoints.

- **Tests**
  - Added a new Web API test project and registered it in the solution for all target CPU configurations.

- **Chores**
  - Added automated dependency update configuration to group and manage OpenCvSharp5 NuGet packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->