### PR TITLE
Add KalmanFilter, DCT/IDCT, and watermark-removal samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,6 @@ paket-files/
 .idea/
 *.sln.iml
 /SamplesCore/*.caffemodel
+
+# Per-sample images written by DisplayHelper when running with --headless
+headless-output/

--- a/Samples/Samples/Core/DctSample.cs
+++ b/Samples/Samples/Core/DctSample.cs
@@ -30,7 +30,10 @@ class DctSample : ConsoleTestBase
         // Log-scale magnitude, just to make the coefficient spectrum visible: it's heavily
         // concentrated in the top-left (low-frequency) corner.
         using var spectrum = new Mat();
-        Cv2.Abs(dct).ToMat().ConvertTo(spectrum, MatType.CV_32F);
+        using (var dctAbs = Cv2.Abs(dct).ToMat())
+        {
+            dctAbs.ConvertTo(spectrum, MatType.CV_32F);
+        }
         using Mat spectrum1 = spectrum + Scalar.All(1);
         Cv2.Log(spectrum1, spectrum1);
         Cv2.Normalize(spectrum1, spectrum1, 0, 255, NormTypes.MinMax);

--- a/Samples/Samples/Core/DctSample.cs
+++ b/Samples/Samples/Core/DctSample.cs
@@ -1,0 +1,65 @@
+﻿using OpenCvSharp;
+using SampleBase;
+using SampleBase.Console;
+using SampleBase.Interfaces;
+
+namespace SamplesCore;
+
+/// <summary>
+/// DCT, inverse DCT, and the energy-compaction property that makes DCT useful for compression
+/// (the same property JPEG relies on): most of the image's information ends up concentrated in
+/// a handful of low-frequency coefficients, so keeping only those and discarding the rest still
+/// gives a recognizable reconstruction.
+/// </summary>
+[SampleCategory(SampleCategory.Core)]
+class DctSample : ConsoleTestBase
+{
+    public override void RunTest(DisplayHelper display)
+    {
+        using var img = Cv2.ImRead(ImagePath.Walkman, ImreadModes.Grayscale);
+
+        // 2D DCT requires even width/height; crop off the last row/column if needed.
+        using var cropped = img[new Rect(0, 0, img.Cols & -2, img.Rows & -2)];
+
+        using var imgF32 = new Mat();
+        cropped.ConvertTo(imgF32, MatType.CV_32F);
+
+        using var dct = new Mat();
+        Cv2.Dct(imgF32, dct);
+
+        // Log-scale magnitude, just to make the coefficient spectrum visible: it's heavily
+        // concentrated in the top-left (low-frequency) corner.
+        using var spectrum = new Mat();
+        Cv2.Abs(dct).ToMat().ConvertTo(spectrum, MatType.CV_32F);
+        using Mat spectrum1 = spectrum + Scalar.All(1);
+        Cv2.Log(spectrum1, spectrum1);
+        Cv2.Normalize(spectrum1, spectrum1, 0, 255, NormTypes.MinMax);
+        spectrum1.ConvertTo(spectrum1, MatType.CV_8U);
+
+        // Keep only the low-frequency coefficients (an 1/8-sized top-left block) and zero out
+        // the rest, then reconstruct: this is the lossy "compression" case.
+        using var dctLowFreqOnly = Mat.Zeros(dct.Size(), MatType.CV_32F).ToMat();
+        var keepRect = new Rect(0, 0, dct.Cols / 8, dct.Rows / 8);
+        using (var src = dct[keepRect])
+        using (var dst = dctLowFreqOnly[keepRect])
+        {
+            src.CopyTo(dst);
+        }
+
+        using var compressed = new Mat();
+        Cv2.Idct(dctLowFreqOnly, compressed);
+        Cv2.Normalize(compressed, compressed, 0, 255, NormTypes.MinMax);
+        compressed.ConvertTo(compressed, MatType.CV_8U);
+
+        // Reconstruct from every coefficient: should match the input almost exactly.
+        using var reconstructed = new Mat();
+        Cv2.Idct(dct, reconstructed);
+        reconstructed.ConvertTo(reconstructed, MatType.CV_8U);
+
+        display.Show(
+            ("Input Image", cropped),
+            ("DCT Spectrum (log magnitude)", spectrum1),
+            ($"Compressed (top-left {keepRect.Width}x{keepRect.Height} coefficients only)", compressed),
+            ("Reconstructed by full Inverse DCT", reconstructed));
+    }
+}

--- a/Samples/Samples/Photo/WatermarkRemovalSample.cs
+++ b/Samples/Samples/Photo/WatermarkRemovalSample.cs
@@ -1,0 +1,58 @@
+﻿using OpenCvSharp;
+using SampleBase;
+using SampleBase.Console;
+using SampleBase.Interfaces;
+
+namespace SamplesCore;
+
+/// <summary>
+/// Removes a text watermark from an image via inpainting.
+/// </summary>
+/// <remarks>
+/// There's no single "remove any watermark" algorithm: the classic approach is inpainting,
+/// which needs a mask of exactly where the watermark pixels are. Real-world watermarks
+/// (semi-transparent stamps, repeating logos) require detecting that mask first (thresholding,
+/// template matching, or a trained model), which is well beyond a single sample. To keep this
+/// self-contained and runnable headlessly, a synthetic text watermark is stamped onto a stock
+/// image and its mask is known exactly by construction, isolating the actual point of interest:
+/// what to do with the mask once you have it.
+/// </remarks>
+[SampleCategory(SampleCategory.Photo)]
+class WatermarkRemovalSample : ConsoleTestBase
+{
+    public override void RunTest(DisplayHelper display)
+    {
+        using var original = Cv2.ImRead(ImagePath.Fruits, ImreadModes.Color);
+
+        using var watermarked = original.Clone();
+        using var mask = new Mat(original.Size(), MatType.CV_8UC1, Scalar.Black);
+
+        const string text = "SAMPLE WATERMARK";
+        var textOrigin = new Point(20, original.Rows - 20);
+        const double fontScale = 1.0;
+        const int thickness = 2;
+
+        // Semi-transparent stamp: blend text directly into a copy of the image...
+        using var watermarkLayer = original.Clone();
+        Cv2.PutText(watermarkLayer, text, textOrigin, HersheyFonts.HersheySimplex, fontScale, Scalar.White, thickness, LineTypes.AntiAlias);
+        Cv2.AddWeighted(original, 0.5, watermarkLayer, 0.5, 0, watermarked);
+
+        // ...and draw the same text at full opacity into a separate mask, so the exact set of
+        // watermark pixels is known without having to detect anything.
+        Cv2.PutText(mask, text, textOrigin, HersheyFonts.HersheySimplex, fontScale, Scalar.White, thickness, LineTypes.AntiAlias);
+        Cv2.Dilate(mask, mask, default, iterations: 1);
+
+        using var restoredTelea = new Mat();
+        Cv2.Inpaint(watermarked, mask, restoredTelea, 3, InpaintTypes.Telea);
+
+        using var restoredNs = new Mat();
+        Cv2.Inpaint(watermarked, mask, restoredNs, 3, InpaintTypes.NS);
+
+        display.Show(
+            ("original", original),
+            ("watermarked", watermarked),
+            ("watermark mask", mask),
+            ("restored (Telea)", restoredTelea),
+            ("restored (Navier-Stokes)", restoredNs));
+    }
+}

--- a/Samples/Samples/Video/KalmanFilterSample.cs
+++ b/Samples/Samples/Video/KalmanFilterSample.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using OpenCvSharp;
+using SampleBase;
+using SampleBase.Console;
+using SampleBase.Interfaces;
+
+namespace SamplesCore;
+
+/// <summary>
+/// Tracks a point rotating around a circle from noisy angle measurements using a Kalman filter.
+/// </summary>
+/// <remarks>https://docs.opencv.org/4.x/dd/d6a/classcv_1_1KalmanFilter.html</remarks>
+[SampleCategory(SampleCategory.Video)]
+class KalmanFilterSample : ConsoleTestBase
+{
+    private const int Width = 640;
+    private const int Height = 640;
+    private const int Radius = 220;
+    private const float AngularVelocity = 0.05f;
+
+    public override void RunTest(DisplayHelper display)
+    {
+        var center = new Point(Width / 2, Height / 2);
+
+        // State: [angle, angular velocity]. Measurement: [angle].
+        using var kalman = new KalmanFilter(2, 1, 0);
+        using var transitionMatrix = new Mat(2, 2, MatType.CV_32F);
+        transitionMatrix.Set(0, 0, 1f);
+        transitionMatrix.Set(0, 1, 1f); // angle(k) = angle(k-1) + angularVelocity(k-1)
+        transitionMatrix.Set(1, 0, 0f);
+        transitionMatrix.Set(1, 1, 1f); // angularVelocity(k) = angularVelocity(k-1)
+        kalman.TransitionMatrix = transitionMatrix;
+        Cv2.SetIdentity(kalman.MeasurementMatrix);
+        Cv2.SetIdentity(kalman.ProcessNoiseCov, Scalar.All(1e-4));
+        Cv2.SetIdentity(kalman.MeasurementNoiseCov, Scalar.All(0.3));
+        Cv2.SetIdentity(kalman.ErrorCovPost, Scalar.All(1));
+        kalman.StatePost.Set(0, 0, 0f);
+        kalman.StatePost.Set(1, 0, AngularVelocity);
+
+        using var measurement = new Mat(1, 1, MatType.CV_32F, Scalar.All(0));
+
+        // Fixed seed so headless output is reproducible across runs.
+        var rng = new Random(12345);
+        float trueAngle = 0f;
+
+        for (int i = 0; i < 300; i++)
+        {
+            using var prediction = kalman.Predict();
+
+            // Advance ground truth and take a noisy angle measurement, as if from a sensor.
+            trueAngle += AngularVelocity;
+            float measuredAngle = trueAngle + ((float)rng.NextDouble() - 0.5f) * 0.3f;
+            measurement.Set(0, 0, measuredAngle);
+
+            using var estimated = kalman.Correct(measurement);
+            float estimatedAngle = estimated.Get<float>(0, 0);
+
+            using var frame = new Mat(Height, Width, MatType.CV_8UC3, Scalar.Black);
+            Cv2.Circle(frame, center, Radius, Scalar.FromRgb(60, 60, 60), 1, LineTypes.AntiAlias);
+            DrawSpoke(frame, center, trueAngle, Scalar.White);
+            DrawSpoke(frame, center, measuredAngle, Scalar.Red);
+            DrawSpoke(frame, center, estimatedAngle, Scalar.LimeGreen);
+            Cv2.PutText(frame, "white=true angle, red=noisy measurement, green=Kalman estimate",
+                new Point(10, 20), HersheyFonts.HersheySimplex, 0.5, Scalar.White);
+
+            if (!display.ShowFrame(("Kalman filter: rotating point tracking", frame)))
+                break;
+        }
+    }
+
+    private static void DrawSpoke(Mat frame, Point center, float angle, Scalar color)
+    {
+        var tip = new Point(
+            center.X + (int)(Radius * Math.Cos(angle)),
+            center.Y + (int)(Radius * Math.Sin(angle)));
+        Cv2.Line(frame, center, tip, color, 2, LineTypes.AntiAlias);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `KalmanFilterSample` (Video category): tracks a point rotating around a circle from noisy angle measurements, drawing the true angle, the noisy measurement, and the Kalman-filtered estimate each frame.
- Adds `DctSample` (Core category): shows the DCT coefficient spectrum, then demonstrates the energy-compaction property DCT-based compression (like JPEG) relies on by reconstructing from only the low-frequency coefficients vs. the full set.
- Adds `WatermarkRemovalSample` (Photo category): stamps a synthetic text watermark onto a stock image (so its exact mask is known by construction) and removes it via `Cv2.Inpaint` (both Telea and Navier-Stokes variants).
- Ignores `Samples/headless-output/`, the per-sample image dump written when running with `--headless`.

All three were built, run with `--headless`, and their output images checked by hand.

Closes #25
Closes #22
Closes #39

## Test plan

- [x] `dotnet build OpenCvSharpSamples.sln --configuration Release` succeeds with 0 errors
- [x] Each new sample runs standalone via `dotnet run -- --headless` with no exceptions
- [x] Verified output PNGs: watermark visibly removed, Kalman estimate tracks closer to true angle than the raw noisy measurement, compressed DCT reconstruction is blurred-but-recognizable while the full reconstruction matches the input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 2D DCT sample demonstrating frequency analysis, lossy reconstruction, and visual comparisons.
  * Added a watermark removal sample using inpainting with both Telea and Navier-Stokes methods.
  * Added a Kalman filter sample that visualizes angle tracking from noisy measurements.
* **Chores**
  * Updated the ignored files list to exclude generated headless-mode sample output images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->