### PR TITLE
Bump OpenCvSharp5 to 5.0.0.20260721, drop WebApi's libdrm2 workaround

### DIFF
--- a/AvaloniaViewer/AvaloniaViewer.csproj
+++ b/AvaloniaViewer/AvaloniaViewer.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
-    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.official.runtime.linux-x64.slim" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.official.runtime.linux-x64.slim" Version="5.0.0.20260721" />
   </ItemGroup>
 
 </Project>

--- a/Samples.WebApi/Dockerfile
+++ b/Samples.WebApi/Dockerfile
@@ -11,13 +11,11 @@ EXPOSE 8080
 
 # OpenCvSharp5.official.runtime.linux-x64.headless keeps the full module set (videoio,
 # dnn, ml, contrib, stitching, barcode, ...) that this app needs (VideoCapture) but is
-# built with highgui disabled, so GTK3/X11/libatomic are gone. libdrm2 is still needed
-# for now: the headless build still links libdrm.so.2 unconditionally, a bug tracked
-# upstream at https://github.com/shimat/opencvsharp/issues/2071 — drop this apt-get
-# step once that lands in a release.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libdrm2 \
-    && rm -rf /var/lib/apt/lists/*
+# built with highgui disabled, so GTK3/X11 are gone. The libdrm2 workaround for
+# https://github.com/shimat/opencvsharp/issues/2071 is no longer needed as of
+# 5.0.0.20260721: the native library no longer references libdrm.so.2 at all
+# (confirmed via `readelf -d`/`strings` and `ldd` against mcr.microsoft.com/dotnet/aspnet:10.0),
+# so no apt-get install is required on top of this base image.
 USER app
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build

--- a/Samples.WebApi/Samples.WebApi.csproj
+++ b/Samples.WebApi/Samples.WebApi.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.official.runtime.linux-x64.headless" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.official.runtime.linux-x64.headless" Version="5.0.0.20260721" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples.Windows/Samples.Windows.csproj
+++ b/Samples.Windows/Samples.Windows.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.WpfExtensions" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.WpfExtensions" Version="5.0.0.20260721" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
-    <PackageReference Include="OpenCvSharp5.GdipExtensions" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5.GdipExtensions" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoCaptureForm/VideoCaptureForm.csproj
+++ b/VideoCaptureForm/VideoCaptureForm.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.GdipExtensions" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.GdipExtensions" Version="5.0.0.20260721" />
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoCaptureWPF/VideoCaptureWPF.csproj
+++ b/VideoCaptureWPF/VideoCaptureWPF.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260719" />
-    <PackageReference Include="OpenCvSharp5.WpfExtensions" Version="5.0.0.20260719" />
+    <PackageReference Include="OpenCvSharp5.runtime.win" Version="5.0.0.20260721" />
+    <PackageReference Include="OpenCvSharp5.WpfExtensions" Version="5.0.0.20260721" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
## Summary

- Bump all `OpenCvSharp5.*` package references from `5.0.0.20260719` to the newly released `5.0.0.20260721`.
- Drop the `apt-get install libdrm2` step from `Samples.WebApi/Dockerfile`, since this release fixes shimat/opencvsharp#2071 (the headless linux-x64 native library no longer references `libdrm.so.2` at all).

## Test plan

- [x] `dotnet build` on the whole solution succeeds with 0 errors
- [x] Ran `ldd` / `readelf -d` / `strings` on the `5.0.0.20260721` `OpenCvSharp5.official.runtime.linux-x64.headless` native library against a plain `mcr.microsoft.com/dotnet/aspnet:10.0` base image (no apt-get install) — confirmed no reference to `libdrm.so.2` (NEEDED entries or dlopen strings)
- [x] Built the updated Dockerfile and ran the container with no apt-get step at all; `/api/cartoonify` (imgcodecs/imgproc) and `/api/frame-analysis` (VideoCapture/videoio) both returned 200 with correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenCvSharp components to the latest package revision across supported applications and samples.
  * Improved Linux headless runtime compatibility by removing an unnecessary graphics library installation workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->